### PR TITLE
ci: enable manual dispatch for multi-platform workflow

### DIFF
--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -251,7 +251,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "vcpkg bootstrap failed with exit code $LASTEXITCODE"
           }
-          & "$vcpkgRoot\vcpkg.exe" install hdf5[hl,szip]:x64-windows zlib:x64-windows
+          & "$vcpkgRoot\vcpkg.exe" install hdf5[szip]:x64-windows zlib:x64-windows
           echo "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # Removed legacy alias step; project links vcpkg libs directly

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -183,6 +183,8 @@ jobs:
 
   windows-cuda:
     runs-on: windows-latest
+    env:
+      VCPKG_COMMIT: 271a5b8850aa50f9a40269cbf3cf414b36e333d6
     strategy:
       fail-fast: false
       matrix:
@@ -242,12 +244,14 @@ jobs:
         run: |
           $vcpkgRoot = "$env:RUNNER_TEMP\vcpkg"
           git clone --depth 1 https://github.com/microsoft/vcpkg $vcpkgRoot
+          git -C $vcpkgRoot fetch --depth 1 origin $env:VCPKG_COMMIT
+          git -C $vcpkgRoot checkout $env:VCPKG_COMMIT
           Write-Host "Bootstrapping vcpkg at: $vcpkgRoot"
           & "$vcpkgRoot\bootstrap-vcpkg.bat" -disableMetrics
           if ($LASTEXITCODE -ne 0) {
             throw "vcpkg bootstrap failed with exit code $LASTEXITCODE"
           }
-          & "$vcpkgRoot\vcpkg.exe" install hdf5[szip]:x64-windows zlib:x64-windows
+          & "$vcpkgRoot\vcpkg.exe" install hdf5[hl,szip]:x64-windows zlib:x64-windows
           echo "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       # Removed legacy alias step; project links vcpkg libs directly

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -1,6 +1,7 @@
 name: CI (multi-platform)
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, develop ]
   pull_request:

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -3,9 +3,9 @@ name: CI (multi-platform)
 on:
   workflow_dispatch:
   push:
-    branches: [ main, develop, cmake-build ]
+    branches: [ main, develop, ci-multi-platform-experiments ]
   pull_request:
-    branches: [ main, cmake-build ]
+    branches: [ main, ci-multi-platform-experiments ]
 
 jobs:
   linux-openmp:

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -3,9 +3,9 @@ name: CI (multi-platform)
 on:
   workflow_dispatch:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, cmake-build ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, cmake-build ]
 
 jobs:
   linux-openmp:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -2,9 +2,9 @@ name: CI - Windows OpenMP
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, cmake-build ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, cmake-build ]
 
 env:
   VCPKG_ROOT: C:\vcpkg

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -2,9 +2,9 @@ name: CI - Windows OpenMP
 
 on:
   push:
-    branches: [ main, develop, cmake-build ]
+    branches: [ main, develop, ci-multi-platform-experiments ]
   pull_request:
-    branches: [ main, cmake-build ]
+    branches: [ main, ci-multi-platform-experiments ]
 
 env:
   VCPKG_ROOT: C:\vcpkg


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables manual (`workflow_dispatch`) triggering for the multi-platform CI workflow and pins the `windows-cuda` vcpkg clone to a specific commit SHA for reproducibility. It also extends both workflow branch filters to include the `ci-multi-platform-experiments` branch.

- `workflow_dispatch` is added only to `ci-multi-platform.yml`; `ci-windows.yml` remains push/PR triggered only, which aligns with the PR title's stated intent.
- The vcpkg pinning in `windows-cuda` uses a shallow fetch of the target commit hash after an initial shallow clone — a valid but slightly roundabout approach that mirrors what the `windows-openmp` job already does via `lukka/run-vcpkg`.
- `VCPKG_COMMIT` is now set independently at the job level in both Windows jobs rather than once at the workflow level, and the branch-filter expansion causes both `ci-windows.yml` and `ci-multi-platform.yml` to build Windows OpenMP on identical triggers.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are confined to CI workflow triggers and vcpkg pinning with no effect on production code.

The functional changes are low-risk CI housekeeping. The duplicated VCPKG_COMMIT variable and overlapping Windows OpenMP builds are the main concerns, but neither breaks anything.

The branch-filter expansion in ci-windows.yml is worth a second look to confirm the duplicate Windows OpenMP build coverage is intentional.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci-multi-platform.yml | Adds workflow_dispatch trigger, expands branch filters, and pins the windows-cuda vcpkg clone to a specific commit SHA; VCPKG_COMMIT is now duplicated at job level in both Windows jobs rather than defined once at workflow level. |
| .github/workflows/ci-windows.yml | Branch filters updated to match ci-multi-platform.yml, resulting in duplicate Windows OpenMP builds on the same branches across both workflows. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger] -->|push to main/develop/ci-multi-platform-experiments| B[ci-multi-platform.yml]
    A -->|pull_request to main/ci-multi-platform-experiments| B
    A -->|workflow_dispatch NEW| B
    A -->|push to main/develop/ci-multi-platform-experiments| C[ci-windows.yml]
    A -->|pull_request to main/ci-multi-platform-experiments| C

    B --> D[linux-openmp]
    B --> E[linux-cuda]
    B --> F[macos-openmp]
    B --> G[windows-cuda VCPKG_COMMIT pinned NEW]
    B --> H[windows-openmp VCPKG_COMMIT already pinned]

    C --> I[build-windows-openmp Duplicate of H]

    style G fill:#d4edda
    style I fill:#fff3cd
```

<sub>Reviews (1): Last reviewed commit: ["Fix vcpkg hdf5 feature set on pinned Win..."](https://github.com/waltsims/kspacefirstorder-unified/commit/1ce51c51ddcfb795ab5008d6a1257f8973a53f26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32455131)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->