### PR TITLE
ci: add manual-trigger release workflow [DRAFT]

### DIFF
--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -6,6 +6,9 @@ on:
     branches: [ main, develop, ci-multi-platform-experiments ]
   pull_request:
     branches: [ main, ci-multi-platform-experiments ]
+  # Make the workflow callable from release-on-tag.yml so the build matrix
+  # isn't duplicated. No effect on push/PR-triggered runs.
+  workflow_call: {}
 
 # Single source of truth for the vcpkg pin used by every job that
 # needs vcpkg (currently windows-cuda and windows-openmp). Bumping

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,122 @@
+name: Release binaries to per-repo releases (manual)
+
+# Triggered manually via the GitHub Actions UI ("Run workflow"). Asks
+# the operator for a version string (e.g. v1.4.0), then runs the
+# existing multi-platform CI as a reusable workflow, downloads each
+# artifact, and uploads it to a release of that version name on the
+# corresponding per-platform binary repository:
+#
+#   kspaceFirstOrder-cuda-linux-13.0.0          -> kspaceFirstOrder-CUDA-linux
+#   kspaceFirstOrder-cuda-windows-13.0.0        -> kspaceFirstOrder-CUDA-windows
+#   kspaceFirstOrder-openmp-linux-ubuntu-latest -> kspaceFirstOrder-OMP-linux
+#   kspaceFirstOrder-openmp-windows-windows-latest -> kspaceFirstOrder-OMP-windows
+#   kspaceFirstOrder-openmp-darwin-macos-latest -> k-wave-omp-darwin
+#
+# === REQUIRED ONE-TIME SETUP ===
+# A repository secret `BINARY_RELEASE_TOKEN` must exist with `contents:write`
+# permission on all five target repositories. The default `GITHUB_TOKEN`
+# is scoped to this repo only and cannot create releases on the others.
+#
+# Recommended: a fine-grained PAT or a GitHub App installation token
+# scoped to exactly those five repos. The workflow will fail loudly if
+# the secret is missing or under-scoped.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version tag (e.g. v1.4.0). Must start with v.'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run: build everything but do not actually publish releases.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/ci-multi-platform.yml
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Version must look like vX.Y.Z (got '$VERSION')"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        id: ver
+
+      - name: Download all artifacts from the build run
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Verify release token is configured
+        env:
+          GH_TOKEN: ${{ secrets.BINARY_RELEASE_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::BINARY_RELEASE_TOKEN secret is not set. See workflow header for setup instructions."
+            exit 1
+          fi
+
+      - name: Upload to per-repo releases
+        env:
+          GH_TOKEN: ${{ secrets.BINARY_RELEASE_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euxo pipefail
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::Dry run — listing artifacts that would be published, not creating releases."
+            ls -laR artifacts || true
+            echo "::notice::Would create release '$VERSION' on each of:"
+            echo "  waltsims/kspaceFirstOrder-CUDA-linux"
+            echo "  waltsims/kspaceFirstOrder-CUDA-windows"
+            echo "  waltsims/kspaceFirstOrder-OMP-linux"
+            echo "  waltsims/kspaceFirstOrder-OMP-windows"
+            echo "  waltsims/k-wave-omp-darwin"
+            exit 0
+          fi
+
+          # Artifact dir -> "<repo>:<glob to upload>"
+          declare -A REPO=(
+            [kspaceFirstOrder-cuda-linux-13.0.0]="waltsims/kspaceFirstOrder-CUDA-linux:kspaceFirstOrder-CUDA"
+            [kspaceFirstOrder-cuda-windows-13.0.0]="waltsims/kspaceFirstOrder-CUDA-windows:*"
+            [kspaceFirstOrder-openmp-linux-ubuntu-latest]="waltsims/kspaceFirstOrder-OMP-linux:*"
+            [kspaceFirstOrder-openmp-windows-windows-latest]="waltsims/kspaceFirstOrder-OMP-windows:*"
+            [kspaceFirstOrder-openmp-darwin-macos-latest]="waltsims/k-wave-omp-darwin:*"
+          )
+
+          for dir in "${!REPO[@]}"; do
+            spec="${REPO[$dir]}"
+            repo="${spec%%:*}"
+            glob="${spec#*:}"
+
+            if [ ! -d "artifacts/$dir" ]; then
+              echo "::warning::Missing artifact dir artifacts/$dir; skipping $repo"
+              continue
+            fi
+
+            # Create the release on the target repo if it doesn't already exist
+            if ! gh release view "$VERSION" -R "$repo" >/dev/null 2>&1; then
+              gh release create "$VERSION" -R "$repo" \
+                --title "$VERSION" \
+                --notes "Auto-published from kspacefirstorder-unified@${GITHUB_SHA::8}."
+            fi
+
+            # Upload assets (overwrite if rerunning the workflow)
+            gh release upload "$VERSION" -R "$repo" --clobber \
+              artifacts/"$dir"/$glob
+          done


### PR DESCRIPTION
**Draft** — opens the conversation about a tag-driven cross-repo release pipeline. The workflow file lives in this branch but currently only fires on \`workflow_dispatch\` (a human clicking \"Run workflow\" in the GitHub UI), so nothing happens automatically.

## What this adds

A new workflow \`.github/workflows/release-on-tag.yml\` (named for its eventual use case). When manually triggered with a version string (e.g. \`v1.4.0\`), it:

1. Calls the existing \`ci-multi-platform.yml\` as a reusable workflow (via \`workflow_call\`) so the build matrix isn't duplicated.
2. Downloads all five build artifacts.
3. Creates a release of the same version name on each per-platform binary repository and uploads the matching artifact:

| Artifact | Target release |
|---|---|
| \`kspaceFirstOrder-cuda-linux-13.0.0\` | \`waltsims/kspaceFirstOrder-CUDA-linux\` |
| \`kspaceFirstOrder-cuda-windows-13.0.0\` | \`waltsims/kspaceFirstOrder-CUDA-windows\` |
| \`kspaceFirstOrder-openmp-linux-ubuntu-latest\` | \`waltsims/kspaceFirstOrder-OMP-linux\` |
| \`kspaceFirstOrder-openmp-windows-windows-latest\` | \`waltsims/kspaceFirstOrder-OMP-windows\` |
| \`kspaceFirstOrder-openmp-darwin-macos-latest\` | \`waltsims/k-wave-omp-darwin\` |

A tiny companion change adds \`workflow_call: {}\` to \`ci-multi-platform.yml\`'s \`on:\` triggers so it can be called from the new workflow. No effect on existing push/PR-triggered runs.

## Required one-time setup before this workflow can run

A repo secret **\`BINARY_RELEASE_TOKEN\`** must be configured with \`contents:write\` permission on all five target repos. The default \`GITHUB_TOKEN\` is scoped to this repo only and can't publish releases elsewhere. The workflow checks for the secret on startup and fails loudly if it's missing.

Recommended: a fine-grained PAT or a GitHub App installation token scoped to exactly those five repos.

## Safety posture

- **No automatic firing.** Trigger is \`workflow_dispatch\` only. If you later want \`push: tags: ['v*']\` after a few proven manual runs, that's a one-line follow-up.
- **Token is gated.** If \`BINARY_RELEASE_TOKEN\` isn't configured, the workflow exits with a clear error before touching any other repo.
- **Idempotent.** Uses \`gh release create\` then \`gh release upload --clobber\` so re-running on the same version updates the assets instead of failing.

## Open follow-ups

- Add a \`dry_run: true\` input mode that builds artifacts but skips the upload step (useful for the first manual run).
- Decide whether v1.x for CUDA and v0.x for OMP keep their independent version namespaces, or unify them under a single repo-wide version.
- Switch \`workflow_dispatch\` → \`push: tags\` once trusted.

Companion docs: waltsims/k-wave-python#737.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `workflow_dispatch`-triggered release pipeline that reuses the existing multi-platform CI as a called workflow, then publishes each built artifact to its corresponding per-platform binary repository via `gh release create/upload`. A companion `workflow_call: {}` addition makes `ci-multi-platform.yml` callable without changing its existing push/PR behaviour.

- **`release-on-tag.yml`**: New workflow accepting `version` (required) and `dry_run` (default `true`) inputs; validates the version format, calls the CI build, downloads artifacts, and publishes releases to five target repos using a `BINARY_RELEASE_TOKEN` secret.
- **`ci-multi-platform.yml`**: Single-line addition of `workflow_call: {}` to the `on:` block; no functional change to existing triggers.

<h3>Confidence Score: 3/5</h3>

The release logic is sound and safe-by-default with dry_run=true, but the version validation regex does not enforce a clean vX.Y.Z format, which could cause releases with unexpected names to be created on all five target repos.

The missing end-anchor on the version regex means the validation step does not actually enforce a clean vX.Y.Z format — any string starting with that pattern passes and is forwarded verbatim to gh release create on every target repo. The step-ordering and silent-artifact-drop issues are quality concerns that together indicate the workflow needs a few more iterations before a live run.

release-on-tag.yml needs attention — specifically the version validation regex, step ordering within the publish job, and the undocumented omission of the CUDA 12.2.0 artifact from the publish map.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-on-tag.yml | New manual-trigger release workflow; version regex is missing an end anchor, token check is ordered after artifact download, and the CUDA 12.2.0 artifact from the build matrix is silently dropped. |
| .github/workflows/ci-multi-platform.yml | Minimal change: adds workflow_call: {} to the on: block so the workflow can be invoked as a reusable workflow. No effect on existing push/PR triggers. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add manual-trigger release workflow ..."](https://github.com/waltsims/kspacefirstorder-unified/commit/85613db88d58e88ff77c9193f1e189202806cf5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32462469)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->