### PR TITLE
ci: stop silencing the linux-openmp smoke test

### DIFF
--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -46,7 +46,14 @@ jobs:
           set -euxo pipefail
           cd build/openmp-linux
           chmod +x ./kspaceFirstOrder-OMP
-          LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/hdf5/serial:${LD_LIBRARY_PATH:-}" ./kspaceFirstOrder-OMP --help | head -n 40
+          # Write --help to a file first, then take the first 40 lines for the
+          # log. If we piped directly into `head -n 40`, head would close the
+          # pipe after reading the 40th line; the binary would get SIGPIPE on
+          # its next write and exit 141, which `pipefail` would then promote
+          # to a smoke-test failure even though --help worked.
+          LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/hdf5/serial:${LD_LIBRARY_PATH:-}" \
+            ./kspaceFirstOrder-OMP --help > /tmp/kspaceFirstOrder-OMP-help.txt
+          head -n 40 /tmp/kspaceFirstOrder-OMP-help.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.3.1

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -45,8 +45,8 @@ jobs:
         run: |
           set -euxo pipefail
           cd build/openmp-linux
-          chmod +x ./kspaceFirstOrder-OMP || true
-          LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/hdf5/serial:${LD_LIBRARY_PATH:-}" ./kspaceFirstOrder-OMP --help | head -n 40 || true
+          chmod +x ./kspaceFirstOrder-OMP
+          LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/hdf5/serial:${LD_LIBRARY_PATH:-}" ./kspaceFirstOrder-OMP --help | head -n 40
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.3.1


### PR DESCRIPTION
Tiny CI fix addressing the open Greptile P2 on #3 (cmake-build branch).

The Linux smoke test had \`|| true\` on both the \`chmod\` and the \`./kspaceFirstOrder-OMP --help\` lines, so a broken or missing binary silently passed through. macOS and Windows smoke tests in the same workflow already exit on failure — the Linux block was the outlier.

\`\`\`yaml
- chmod +x ./kspaceFirstOrder-OMP || true
+ chmod +x ./kspaceFirstOrder-OMP
- LD_LIBRARY_PATH=... ./kspaceFirstOrder-OMP --help | head -n 40 || true
+ LD_LIBRARY_PATH=... ./kspaceFirstOrder-OMP --help | head -n 40
\`\`\`

If a recent build legitimately exits non-zero on \`--help\`, that should be fixed in the binary rather than masked here.

## Why a separate PR

The fix logically belongs on \`cmake-build\` (where the Greptile comment was raised), but since the \`ci-multi-platform-experiments\` branch is a strict superset of \`cmake-build\` (carries my dedupe + 5 prior CI fixes), targeting experiments avoids a future merge-direction conflict. Once experiments lands on main, both branches converge.

Resolves the Greptile P2 on kspacefirstorder-unified#3.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Linux OpenMP smoke test by removing two `|| true` guards that silently swallowed build and binary failures, and simultaneously works around the SIGPIPE/`pipefail` trap that would have made the bare fix flaky.

- `chmod +x ./kspaceFirstOrder-OMP` and the `--help` invocation previously fell back to success regardless of outcome; both now propagate failures as intended.
- The `--help` output is redirected to a temp file before being passed to `head -n 40`, sidestepping the SIGPIPE that `pipefail` would have promoted to a smoke-test failure when the binary wrote more than 40 lines.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes silent-failure guards and correctly handles the SIGPIPE edge case via temp-file redirection.

The diff is narrow and surgical: two || true guards are removed and the pipe-to-head pattern is replaced with a file-redirect pattern that eliminates the SIGPIPE risk under pipefail. The logic matches the macOS and Windows smoke tests and the inline comment clearly documents the reasoning. No production code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci-multi-platform.yml | Removes || true guards from the Linux smoke-test step and rewrites the --help pipe to avoid SIGPIPE under pipefail by capturing output to a temp file first. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions Linux runner
    participant BIN as kspaceFirstOrder-OMP
    participant TMP as tmp help file
    participant HEAD as head -n 40

    Note over GH: set -euxo pipefail active

    GH->>GH: chmod +x kspaceFirstOrder-OMP
    Note over GH: Failure now propagates instead of being silenced

    GH->>BIN: kspaceFirstOrder-OMP --help redirect to tmp file
    BIN-->>TMP: full help output written to disk
    Note over BIN: Exit code now visible to shell

    GH->>HEAD: head -n 40 tmp file
    HEAD-->>GH: first 40 lines printed to CI log
    Note over HEAD: head reads file not a pipe so no SIGPIPE risk
```

<sub>Reviews (2): Last reviewed commit: ["Fix smoke test SIGPIPE under pipefail (G..."](https://github.com/waltsims/kspacefirstorder-unified/commit/d94b547a8ff2141ec584497cf7a92ab47a49a540) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32457972)</sub>

<!-- /greptile_comment -->