### PR TITLE
ci: address four Greptile P1/P2 findings on experiments branch

### DIFF
--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -45,8 +45,15 @@ jobs:
         run: |
           set -euxo pipefail
           cd build/openmp-linux
-          chmod +x ./kspaceFirstOrder-OMP || true
-          LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/hdf5/serial:${LD_LIBRARY_PATH:-}" ./kspaceFirstOrder-OMP --help | head -n 40 || true
+          chmod +x ./kspaceFirstOrder-OMP
+          # Write --help to a file first, then take the first 40 lines for the
+          # log. If we piped directly into `head -n 40`, head would close the
+          # pipe after reading the 40th line; the binary would get SIGPIPE on
+          # its next write and exit 141, which `pipefail` would then promote
+          # to a smoke-test failure even though --help worked.
+          LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/hdf5/serial:${LD_LIBRARY_PATH:-}" \
+            ./kspaceFirstOrder-OMP --help > /tmp/kspaceFirstOrder-OMP-help.txt
+          head -n 40 /tmp/kspaceFirstOrder-OMP-help.txt
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.3.1
@@ -321,19 +328,11 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
-
-      - name: Cache vcpkg artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.VCPKG_ROOT }}\installed
-            ${{ env.VCPKG_ROOT }}\packages
-          key: >
-            vcpkg-${{ runner.os }}-${{ env.VCPKG_COMMIT }}-${{
-            hashFiles('repos/kspaceFirstOrder-openmp-windows/vcpkg.json') }}
-          restore-keys: |
-            vcpkg-${{ runner.os }}-${{ env.VCPKG_COMMIT }}-
-            vcpkg-${{ runner.os }}-
+          # run-vcpkg@v11 handles binary caching internally via GitHub
+          # Actions cache (keyed off vcpkg commit + vcpkg.json hash), so
+          # the previous explicit `actions/cache@v4` step here was
+          # redundant — it cached the same paths twice with slightly
+          # different keys, racing the action's own cache.
 
       - name: Configure (OpenMP, Windows)
         run: >
@@ -355,7 +354,7 @@ jobs:
 
       - name: Upload artifacts (OpenMP Windows)
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: kspaceFirstOrder-openmp-windows-windows-latest
           path: |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project is a unified C++ implementation of the k-Wave toolbox that accelera
 
 ### Windows (OpenMP via CMake + vcpkg)
 
-The Windows OpenMP implementation now ships with a CMake build that mirrors the upstream `kspaceFirstOrder-OMP-windows` repository and is exercised in `.github/workflows/ci-windows.yml`. To reproduce the build locally:
+The Windows OpenMP implementation now ships with a CMake build that mirrors the upstream `kspaceFirstOrder-OMP-windows` repository and is exercised by the `windows-openmp` job in `.github/workflows/ci-multi-platform.yml`. To reproduce the build locally:
 
 1. Install Visual Studio 2022 (Desktop development with C++ workload), [Ninja](https://ninja-build.org/), and bootstrap [vcpkg](https://github.com/microsoft/vcpkg) (for example into `C:\vcpkg`).
 2. Update submodules so the Windows sources and manifest (`vcpkg.json`) are present:


### PR DESCRIPTION
Consolidates all the open review feedback on #9 (experiments → main) and the related #8 (smoke-test) into a single PR against experiments. After this lands, both #8 and the four threads on #9 can be resolved and the consolidated experiments → main PR is unblocked.

| # | Severity | Issue | Fix |
|---|---|---|---|
| 1 | P1 | Smoke test SIGPIPE: `--help \| head -n 40` under \`pipefail\` fails when binary writes more than 40 lines (head closes pipe → SIGPIPE → exit 141 → pipefail caught) | Write \`--help\` to a temp file, then \`head\` the file |
| 2 | P2 | Redundant explicit \`actions/cache@v4\` step in windows-openmp (lukka/run-vcpkg@v11 caches internally) | Removed |
| 3 | P2 | windows-openmp \`upload-artifact\` floats at \`@v4\` while every other upload pins \`@v4.3.1\` | Pinned to \`@v4.3.1\` |
| 4 | P2 | README references deleted \`ci-windows.yml\` (deleted in #7) | Repointed to \`windows-openmp\` job in \`ci-multi-platform.yml\` |

## Suggested follow-ups

- Close #8 as superseded by this PR (the smoke-test fix is included here).
- Once this merges, all 4 unresolved threads on #9 become moot — resolve and merge #9 to land the full CMake migration on main.

## Test plan

- [ ] CI passes on this branch with the SIGPIPE-safe smoke test
- [ ] No actions/cache@v4 step appears in the windows-openmp job logs
- [ ] All upload-artifact actions resolve to v4.3.1

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates four CI fixes from open review threads on the experiments branch: a SIGPIPE-safe smoke test for the Linux binary, removal of a redundant `actions/cache@v4` step in the windows-openmp job, pinning the Windows `upload-artifact` action to `v4.3.1`, and updating a README reference from the deleted `ci-windows.yml` to the correct workflow.

- **Smoke test (Linux)**: Redirects `--help` output to a temp file before piping to `head`, eliminating the SIGPIPE/exit-141 false-negative under `set -euxo pipefail`. Also removes the old `|| true` guard, which now allows genuine binary failures to surface correctly.
- **Windows-openmp job**: Drops the redundant `actions/cache@v4` step (internal caching by `lukka/run-vcpkg@v11` made it redundant) and aligns `upload-artifact` to `v4.3.1` to match every other job in the workflow.
- **README**: Corrects the stale reference to the deleted `ci-windows.yml`, now pointing to the `windows-openmp` job in `ci-multi-platform.yml`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four changes are narrow and correct, with no unintended side-effects on other jobs.

The SIGPIPE fix is technically sound: redirecting to a temp file eliminates the broken-pipe condition entirely, and dropping `|| true` means genuine binary failures will now correctly fail CI rather than being silently swallowed. The cache-step removal is safe because `lukka/run-vcpkg@v11` manages its own GitHub Actions cache. The upload-artifact pin and README update are mechanical. No logic regressions are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci-multi-platform.yml | Smoke test fixed with temp-file redirect to avoid SIGPIPE; redundant cache step removed; upload-artifact pinned to v4.3.1. All changes are correct and well-commented. |
| README.md | Reference to the deleted ci-windows.yml corrected to the `windows-openmp` job in ci-multi-platform.yml — straightforward documentation fix. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Smoke test step\nset -euxo pipefail] --> B{Approach}

    B -->|Old — direct pipe| C["./kspaceFirstOrder-OMP --help\n| head -n 40 || true"]
    C --> D[head reads 40 lines\nthen closes read end]
    D --> E[Binary gets SIGPIPE\non next write attempt]
    E --> F["Binary exits 141\npipefail catches it"]
    F --> G["|| true suppresses…\nbut masks real failures too"]

    B -->|New — temp file| H["./kspaceFirstOrder-OMP --help\n> /tmp/…-help.txt"]
    H --> I[Binary writes all output\nno pipe, no SIGPIPE]
    I --> J[Binary exits normally\n0 on success]
    J --> K["head -n 40 /tmp/…-help.txt\n(reads from file, not pipe)"]
    K --> L[Step exits 0\nCI passes]

    style G fill:#f88,stroke:#c00
    style L fill:#8f8,stroke:#080
```

<sub>Reviews (2): Last reviewed commit: ["ci: address four Greptile P1/P2 findings..."](https://github.com/waltsims/kspacefirstorder-unified/commit/eadceb01320c8e3f03c342ed151ea74515ac6174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32458725)</sub>

<!-- /greptile_comment -->