### PR TITLE
plans: add 08-pragmatic-mirror-consolidation.md

### DIFF
--- a/plans/08-pragmatic-mirror-consolidation.md
+++ b/plans/08-pragmatic-mirror-consolidation.md
@@ -1,0 +1,185 @@
+# Pragmatic mirror consolidation (release-cost reduction)
+
+> **Companion to [`07-unification-roadmap.md`](07-unification-roadmap.md).**
+> That document targets the long-horizon end state — a single shared core
+> library with platform/accelerator adapters. This document targets the
+> *next concrete step*: the smallest structural change that captures most
+> of the operational payoff, justified by what shipping a release in this
+> codebase actually costs today.
+
+## Problem
+
+The k-wave binary distribution lives across **five mirror repos**, each
+mirroring an upstream MATLAB k-Wave per-platform tarball:
+
+| Repo                                | What it ships     | Build system today |
+|-------------------------------------|-------------------|--------------------|
+| `kspaceFirstOrder-CUDA-linux`       | Linux CUDA binary | Makefile + (now) CMakeLists.txt |
+| `kspaceFirstOrder-CUDA-windows`     | Windows CUDA binary | `.vcxproj` + (now) CMakeLists.txt |
+| `kspaceFirstOrder-OMP-linux`        | Linux OMP binary  | CMakeLists.txt |
+| `kspaceFirstOrder-OMP-windows`      | Windows OMP binary| CMakeLists.txt + vcpkg.json |
+| `k-wave-omp-darwin`                 | macOS OMP binary  | CMakeLists.txt (per-subdir) |
+
+`kspacefirstorder-unified` coordinates them via git submodules + CI.
+
+The C++ source within each **CUDA pair** is 95%+ identical (same upstream
+Brno SC@FIT code, just different build wrappers + per-platform vcpkg /
+HDF5 / cuFFT lookups). Same for the **OMP triple**. The only material
+per-platform differences are in build glue: include paths, vcpkg vs
+Homebrew, MSBuild vs make, fast-math flag dialect (apple-clang vs gcc).
+
+## Evidence — what shipping v1.4.0 actually cost
+
+Shipping **one logical feature** (NVIDIA Blackwell / sm_120 support)
+on 2026-05-16 took roughly **12 PRs**:
+
+| # | Repo | PR | What |
+|---|---|---|---|
+| 1 | CUDA-linux | #5 | Makefile: add sm_120 with CUDA-version gate |
+| 2 | CUDA-windows | #1 | Makefile: add sm_120 |
+| 3 | CUDA-windows | #2 | vcxproj: CUDA 12.2/13.0 fallback + ResolvedVcpkgRoot |
+| 4 | CUDA-linux | #4 | CUFFT `#ifdef CUDART_VERSION < 13000` |
+| 5 | CUDA-windows | (in #2) | Same CUFFT `#ifdef` — duplicated by hand |
+| 6 | CUDA-linux | #6 | Add CMakeLists.txt + cmake/SetupCUDA.cmake |
+| 7 | CUDA-windows | #3 | Same CMakeLists.txt + SetupCUDA.cmake — duplicated by hand |
+| 8 | CUDA-linux | #7 | Pre-`enable_language(CUDA)` arch pre-filter |
+| 9 | CUDA-windows | #4 | Same pre-filter — duplicated by hand |
+| 10 | unified | #5 | Submodule SHA bumps |
+| 11 | unified | #7 | CI dedupe (delete duplicate `ci-windows.yml`) |
+| 12 | unified | #9, #10, #8 | Smoke-test fixes, cache cleanup, README ref repair |
+
+**~6 of those 12 PRs are pure mirror-duplication tax**: the same diff
+applied twice because we have separate CUDA-linux and CUDA-windows
+repos. Plus the manual submodule-SHA dance in unified after every
+binary-repo merge (re-bumped 4 times during this release).
+
+Plus we hit a real bug nobody would have hit with a single repo: the
+`enable_language(CUDA)` test compile blew up on CUDA 12.2 because the
+CMakeLists.txt's default arch list (which we'd duplicated, identically,
+across both repos) included `sm_100` and `sm_120`. One repo, one CMake
+file, one fix. Two repos, two CMake files, two fixes — easy to forget
+the second.
+
+## Proposal — pragmatic consolidation in two steps
+
+### Step 1: collapse the CUDA pair into a single `kspace-cuda` repo
+
+The two repos currently differ in:
+- `Makefile` (Linux only) vs `kspaceFirstOrder-CUDA.vcxproj` (Windows only)
+- `CufftComplexMatrix.cpp` indentation/whitespace (cosmetic)
+- A handful of `#ifdef _WIN32` / `__linux__` blocks that exist in both
+  already
+
+Target structure (`kspace-cuda/`):
+```
+kspace-cuda/
+├── CMakeLists.txt                 (single source of truth; today's per-platform
+│                                   CMakeLists.txt collapses into this with
+│                                   `if(WIN32)` branches for vcpkg vs system HDF5)
+├── cmake/
+│   ├── SetupCUDA.cmake            (already unified; the prefilter fix happened
+│                                   once here instead of twice)
+│   └── PlatformDeps.cmake         (NEW — picks vcpkg on Windows, system pkg
+│                                   on Linux, exposes `kspace::hdf5` target)
+├── Containers/   …                (shared C++ source — single copy)
+├── KSpaceSolver/ …
+├── MatrixClasses/ …               (CufftComplexMatrix.cpp lives here once)
+└── Logger/ …
+```
+
+Retirements:
+- `Makefile` (deleted; CMake covers both Linux and Windows builds)
+- `kspaceFirstOrder-CUDA.vcxproj` (deleted; CMake generates one if needed)
+
+The two upstream mirrors become a single repo. Future releases:
+- New CUDA arch → one PR, one Makefile-equivalent (CMake), one CUFFT update
+- Submodule pin in unified: one entry instead of two
+
+### Step 2: collapse the OMP triple into a single `kspace-openmp` repo
+
+Same pattern, larger payoff because it's three repos collapsing to one.
+Per-platform differences:
+
+| Concern | Linux | Windows | macOS |
+|---|---|---|---|
+| Dep manager | apt / EBROOT | vcpkg | Homebrew |
+| OpenMP flag | `-fopenmp` (gcc) | `/openmp` (MSVC) | `-Xpreprocessor -fopenmp -lomp` (apple-clang + libomp) |
+| Fast-math | `-ffast-math` | `/fp:fast` | `-fno-fast-math -ffp-contract=fast` (NaN fix from k-wave-omp-darwin#3) |
+| HDF5 lib name | `libhdf5_hl` (static or shared) | `hdf5_hl-static.lib` | brew's `libhdf5_hl` |
+
+All of these are routine `if(WIN32)/if(APPLE)` branches in a single
+CMakeLists.txt. The k-wave-omp-darwin per-subdirectory CMakeLists
+style would carry over unchanged.
+
+### Step 3: webhook-driven submodule auto-bump in unified
+
+A small GHA in unified that runs on `workflow_dispatch` (or on a webhook
+from the binary repos via `repository_dispatch`):
+
+```yaml
+on:
+  repository_dispatch:
+    types: [binary-repo-pushed]
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+          token: ${{ secrets.UNIFIED_BUMP_TOKEN }}
+      - run: |
+          git submodule update --remote
+          git diff --quiet || (
+            git config user.email auto-bump@k-wave.org
+            git config user.name "Auto-bump bot"
+            git commit -am "Auto-bump submodules"
+            git push
+          )
+```
+
+Combined with steps 1 and 2 this becomes a 2-line update (the two
+remaining submodules) on any binary-repo push, then CI validates.
+
+## Migration plan (incremental, low-risk)
+
+The trick is doing this **without** breaking the current k-wave-python
+download flow.
+
+1. **Phase A — make CMake the only path on each existing repo.**
+   Retire `Makefile` and `.vcxproj` per binary repo. Already done for
+   `kspaceFirstOrder-OMP-{linux,windows,darwin}`; still pending on the
+   CUDA pair (where the legacy Makefile + .vcxproj still ship). Tracking:
+   leave the legacy build files alongside CMake for one release, then
+   delete in the release after that.
+
+2. **Phase B — create `kspace-cuda` as a new repo.**
+   Initial commit is the union of `kspaceFirstOrder-CUDA-{linux,windows}`'s
+   source with one shared CMakeLists.txt (CMake-only). Tag `v1.5.0` at
+   creation. unified gets a new submodule pin alongside (not replacing)
+   the existing two, so we can A/B compare builds for one release.
+
+3. **Phase C — flip k-wave-python URL pins** from the per-platform
+   binary repos to the new `kspace-cuda`. Both upload paths produce the
+   same artifact bytes; k-wave-python `__init__.py` just changes which
+   release URL it downloads from. Validated against the A/B from Phase B.
+
+4. **Phase D — archive the per-platform CUDA mirrors.** Keep them
+   read-only for users still pinned to older k-wave-python releases.
+
+5. **Phase E — repeat A-D for the OMP triple.**
+
+## Out of scope for this plan
+
+- Full unification into a single core library with adapters (that's
+  `07-unification-roadmap.md`).
+- Changes to the k-wave-python Python solver path (independent of
+  binary distribution).
+- Changes to upstream MATLAB k-Wave's own structure.
+
+## Acceptance criteria
+
+- Shipping a new CUDA arch (e.g. sm_130 when Rubin lands) requires:
+  - ≤ 2 PRs (one to `kspace-cuda`, one to k-wave-python `__init__.py`)
+  - 0 manual submodule-SHA edits on unified (auto-bumped)
+- Per-release operational time approximately ⅕ of the v1.4.0 baseline.


### PR DESCRIPTION
*(Re-opened against \`main\` after PR #9 merged and \`ci-multi-platform-experiments\` was deleted — original was #11.)*

Adds \`plans/08-pragmatic-mirror-consolidation.md\` — a near-term, evidence-driven companion to the existing \`plans/07-unification-roadmap.md\`.

## Why

The v1.4.0 (Blackwell / sm_120) release exercise on 2026-05-16 shipped one logical feature and required ~12 PRs across 5 binary repos plus this unified one. Roughly half of those PRs were the exact same diff applied twice because cuda-linux and cuda-windows are separate repos that share 95%+ of their C++ source.

## What

The plan proposes:
1. **Collapse the CUDA pair** (kspaceFirstOrder-CUDA-{linux,windows}) into one \`kspace-cuda\` repo with \`if(WIN32)\` in CMake.
2. **Collapse the OMP triple** (kspaceFirstOrder-OMP-{linux,windows} + k-wave-omp-darwin) into one \`kspace-openmp\` repo.
3. **Webhook-driven submodule auto-bump** in unified so per-release manual SHA edits go away.

Plus a 5-phase incremental migration that doesn't break the k-wave-python download flow during transition.

## Acceptance

Shipping a future CUDA arch should require ≤ 2 PRs (one to \`kspace-cuda\`, one to k-wave-python URL pins) and 0 manual submodule-SHA edits. Approximately ⅕ the per-release operational time of v1.4.0.

## Not in scope

Full unification into a single core library — that's \`plans/07-unification-roadmap.md\`. This plan is the pragmatic *next step* toward that destination.

Docs-only PR; no code changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds `plans/08-pragmatic-mirror-consolidation.md`, a near-term companion to the existing unification roadmap, motivated by the 12-PR cost of shipping Blackwell/sm_120 support for v1.4.0.

- **Repo consolidation**: proposes collapsing the two CUDA mirror repos into one `kspace-cuda` repo and the three OMP repos into one `kspace-openmp` repo, with platform differences handled via `if(WIN32)/if(APPLE)` CMake branches.
- **Auto-bump GHA**: sketches a `repository_dispatch`-triggered workflow that runs `git submodule update --remote` and pushes directly to unified, eliminating manual SHA edits.
- **Phased migration**: defines five phases (A–E) designed to avoid breaking the k-wave-python download flow during transition, with acceptance criteria targeting \u2264 2 PRs per future CUDA arch release."

<h3>Confidence Score: 4/5</h3>

Safe to merge — no code changes, only a planning document that records context and proposes future work.

The plan is well-structured and evidence-driven. Three minor gaps worth addressing before the plan is executed: a factual inconsistency in the evidence table (Makefile vs vcxproj for CUDA-windows), the auto-bump git push not accounting for branch-protection rules, and Phase D not explicitly mentioning removal of stale submodule entries from unified. None of these block merging the document itself.

plans/08-pragmatic-mirror-consolidation.md — the auto-bump GHA snippet and Phase D migration step warrant a second look before implementation begins.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| plans/08-pragmatic-mirror-consolidation.md | New planning document proposing CUDA pair and OMP triple repo consolidation with an auto-bump GHA snippet; minor factual inconsistency in the evidence table and a branch-protection gap in the workflow sketch |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph TODAY["Today (5 repos + unified)"]
        CL[kspaceFirstOrder-CUDA-linux]
        CW[kspaceFirstOrder-CUDA-windows]
        OL[kspaceFirstOrder-OMP-linux]
        OW[kspaceFirstOrder-OMP-windows]
        OD[k-wave-omp-darwin]
        U1[kspacefirstorder-unified\ngit submodules x5]
        CL & CW & OL & OW & OD --> U1
    end
    subgraph PROPOSED["Proposed (2 repos + unified)"]
        KC[kspace-cuda\nLinux + Windows]
        KO[kspace-openmp\nLinux + Windows + macOS]
        U2[kspacefirstorder-unified\ngit submodules x2\nauto-bump GHA]
        KC & KO --> U2
    end
    subgraph MIGRATION["Migration phases"]
        A[Phase A: CMake-only on existing repos]
        B[Phase B: create kspace-cuda]
        C[Phase C: flip k-wave-python URL pins]
        D[Phase D: archive CUDA mirrors]
        E[Phase E: repeat for OMP triple]
        A --> B --> C --> D --> E
    end
    TODAY -. "collapse" .-> PROPOSED
    MIGRATION -. "execution path" .-> PROPOSED
```

<sub>Reviews (1): Last reviewed commit: ["plans: add 08-pragmatic-mirror-consolida..."](https://github.com/waltsims/kspacefirstorder-unified/commit/6ab7b82ea55f0ce6d0bbd4ab60bc14a447acc14b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32462057)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->