### PR TITLE
Rewrite release-on-tag.yml: publish one unified release (unified#13)

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -29,7 +29,7 @@ on:
         default: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -38,6 +38,11 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    # contents:write scoped to this job only so the reusable build
+    # workflow (which runs third-party actions and external clones)
+    # inherits only read access.
+    permissions:
+      contents: write
     steps:
       - name: Validate version input
         env:
@@ -100,8 +105,13 @@ jobs:
         run: |
           set -euxo pipefail
           if ! gh release view "$VERSION" >/dev/null 2>&1; then
+            # Mark vX.Y.Z-rcN / -betaN / etc. as prerelease so it doesn't
+            # show up as "Latest" on the releases page.
+            PRERELEASE_FLAG=()
+            [[ "$VERSION" =~ -[a-zA-Z] ]] && PRERELEASE_FLAG=(--prerelease)
             gh release create "$VERSION" \
               --title "$VERSION" \
+              "${PRERELEASE_FLAG[@]}" \
               --notes "Unified binaries for kspaceFirstOrder backends across all supported platforms. Built from ${GITHUB_SHA::8}."
           fi
           gh release upload "$VERSION" --clobber stage/*

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -38,21 +38,23 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    # contents:write scoped to this job only so the reusable build
-    # workflow (which runs third-party actions and external clones)
-    # inherits only read access.
+    # Job-scoped write so the reusable build job (third-party actions,
+    # external clones) inherits read-only.
     permissions:
       contents: write
     steps:
-      - name: Validate version input
+      - name: Parse version input
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "::error::Version must look like vX.Y.Z (got '$VERSION')"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Version must look like vX.Y.Z or vX.Y.Z-suffix (got '$VERSION')"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Any -suffix → prerelease (rc1, beta, 1, alpha.2, etc.)
+          [[ "$VERSION" == *-* ]] && echo "prerelease=true" >> "$GITHUB_OUTPUT" \
+                                  || echo "prerelease=false" >> "$GITHUB_OUTPUT"
         id: ver
 
       - name: Download all build artifacts
@@ -65,25 +67,20 @@ jobs:
           set -euxo pipefail
           mkdir -p stage
 
-          # Linux
           cp artifacts/kspaceFirstOrder-cuda-linux-13.0.0/kspaceFirstOrder-CUDA \
              stage/kspaceFirstOrder-CUDA-linux
           cp artifacts/kspaceFirstOrder-openmp-linux-ubuntu-latest/kspaceFirstOrder-OMP \
              stage/kspaceFirstOrder-OMP-linux
-
-          # macOS
           cp artifacts/kspaceFirstOrder-openmp-darwin-macos-latest/kspaceFirstOrder-OMP \
              stage/kspaceFirstOrder-OMP-darwin
-
-          # Windows .exe files (rename to disambiguate the two backends)
           cp artifacts/kspaceFirstOrder-cuda-windows-13.0.0/kspaceFirstOrder-CUDA.exe \
              stage/kspaceFirstOrder-CUDA-windows.exe
           cp artifacts/kspaceFirstOrder-openmp-windows-windows-latest/kspaceFirstOrder-OMP.exe \
              stage/kspaceFirstOrder-OMP-windows.exe
 
-          # Windows runtime DLLs (shipped from the OMP build; both backends
+          # Windows runtime DLLs ship from the OMP build only; both backends
           # consume them since k-wave-python places both .exe files in the
-          # same kwave/bin/windows/ directory).
+          # same kwave/bin/windows/ directory.
           cp artifacts/kspaceFirstOrder-openmp-windows-windows-latest/*.dll stage/
 
           ls -la stage/
@@ -102,13 +99,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.ver.outputs.version }}
+          PRERELEASE: ${{ steps.ver.outputs.prerelease }}
         run: |
           set -euxo pipefail
           if ! gh release view "$VERSION" >/dev/null 2>&1; then
-            # Mark vX.Y.Z-rcN / -betaN / etc. as prerelease so it doesn't
-            # show up as "Latest" on the releases page.
             PRERELEASE_FLAG=()
-            [[ "$VERSION" =~ -[a-zA-Z] ]] && PRERELEASE_FLAG=(--prerelease)
+            [[ "$PRERELEASE" == "true" ]] && PRERELEASE_FLAG=(--prerelease)
             gh release create "$VERSION" \
               --title "$VERSION" \
               "${PRERELEASE_FLAG[@]}" \

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,41 +1,35 @@
-name: Release binaries to per-repo releases (manual)
+name: Release unified binaries (manual)
 
-# Triggered manually via the GitHub Actions UI ("Run workflow"). Asks
-# the operator for a version string (e.g. v1.4.0), then runs the
-# existing multi-platform CI as a reusable workflow, downloads each
-# artifact, and uploads it to a release of that version name on the
-# corresponding per-platform binary repository:
+# Publishes a single GitHub release on this repo containing all five
+# platform/backend binaries (plus Windows runtime DLLs). Triggered
+# manually via the Actions UI ("Run workflow"): operator supplies a
+# version string (e.g. v1.4.2) and toggles dry_run.
 #
-#   kspaceFirstOrder-cuda-linux-13.0.0          -> kspaceFirstOrder-CUDA-linux
-#   kspaceFirstOrder-cuda-windows-13.0.0        -> kspaceFirstOrder-CUDA-windows
-#   kspaceFirstOrder-openmp-linux-ubuntu-latest -> kspaceFirstOrder-OMP-linux
-#   kspaceFirstOrder-openmp-windows-windows-latest -> kspaceFirstOrder-OMP-windows
-#   kspaceFirstOrder-openmp-darwin-macos-latest -> k-wave-omp-darwin
+# This replaces the prior per-mirror release flow (unified#13). All
+# artifacts now live on one release tag on this repo — one SHA, one
+# build, one set of platform-suffixed assets — and k-wave-python
+# (waltsims/k-wave-python#738) points its URL_DICT at this single
+# release URL instead of five separate mirror URLs.
 #
-# === REQUIRED ONE-TIME SETUP ===
-# A repository secret `BINARY_RELEASE_TOKEN` must exist with `contents:write`
-# permission on all five target repositories. The default `GITHUB_TOKEN`
-# is scoped to this repo only and cannot create releases on the others.
-#
-# Recommended: a fine-grained PAT or a GitHub App installation token
-# scoped to exactly those five repos. The workflow will fail loudly if
-# the secret is missing or under-scoped.
+# Permissions: GITHUB_TOKEN's `contents: write` suffices since the
+# release lives on this repo. The prior BINARY_RELEASE_TOKEN PAT is
+# no longer needed.
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version tag (e.g. v1.4.0). Must start with v.'
+        description: 'Release version tag (e.g. v1.4.2). Must start with v.'
         required: true
         type: string
       dry_run:
-        description: 'Dry run: build everything but do not actually publish releases.'
+        description: 'Dry run: build everything but do not actually publish the release.'
         required: false
         type: boolean
         default: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -56,67 +50,58 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         id: ver
 
-      - name: Download all artifacts from the build run
+      - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
-      - name: Verify release token is configured
-        env:
-          GH_TOKEN: ${{ secrets.BINARY_RELEASE_TOKEN }}
-        run: |
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::BINARY_RELEASE_TOKEN secret is not set. See workflow header for setup instructions."
-            exit 1
-          fi
-
-      - name: Upload to per-repo releases
-        env:
-          GH_TOKEN: ${{ secrets.BINARY_RELEASE_TOKEN }}
-          VERSION: ${{ steps.ver.outputs.version }}
-          DRY_RUN: ${{ inputs.dry_run }}
+      - name: Stage assets with platform-suffixed names
         run: |
           set -euxo pipefail
+          mkdir -p stage
 
-          if [ "$DRY_RUN" = "true" ]; then
-            echo "::notice::Dry run — listing artifacts that would be published, not creating releases."
-            ls -laR artifacts || true
-            echo "::notice::Would create release '$VERSION' on each of:"
-            echo "  waltsims/kspaceFirstOrder-CUDA-linux"
-            echo "  waltsims/kspaceFirstOrder-CUDA-windows"
-            echo "  waltsims/kspaceFirstOrder-OMP-linux"
-            echo "  waltsims/kspaceFirstOrder-OMP-windows"
-            echo "  waltsims/k-wave-omp-darwin"
-            exit 0
+          # Linux
+          cp artifacts/kspaceFirstOrder-cuda-linux-13.0.0/kspaceFirstOrder-CUDA \
+             stage/kspaceFirstOrder-CUDA-linux
+          cp artifacts/kspaceFirstOrder-openmp-linux-ubuntu-latest/kspaceFirstOrder-OMP \
+             stage/kspaceFirstOrder-OMP-linux
+
+          # macOS
+          cp artifacts/kspaceFirstOrder-openmp-darwin-macos-latest/kspaceFirstOrder-OMP \
+             stage/kspaceFirstOrder-OMP-darwin
+
+          # Windows .exe files (rename to disambiguate the two backends)
+          cp artifacts/kspaceFirstOrder-cuda-windows-13.0.0/kspaceFirstOrder-CUDA.exe \
+             stage/kspaceFirstOrder-CUDA-windows.exe
+          cp artifacts/kspaceFirstOrder-openmp-windows-windows-latest/kspaceFirstOrder-OMP.exe \
+             stage/kspaceFirstOrder-OMP-windows.exe
+
+          # Windows runtime DLLs (shipped from the OMP build; both backends
+          # consume them since k-wave-python places both .exe files in the
+          # same kwave/bin/windows/ directory).
+          cp artifacts/kspaceFirstOrder-openmp-windows-windows-latest/*.dll stage/
+
+          ls -la stage/
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          echo "::notice::Dry run — would create release '$VERSION' on this repo with the following assets:"
+          ls -la stage/
+          echo "::notice::Re-run with dry_run=false to actually publish."
+
+      - name: Publish release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euxo pipefail
+          if ! gh release view "$VERSION" >/dev/null 2>&1; then
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --notes "Unified binaries for kspaceFirstOrder backends across all supported platforms. Built from ${GITHUB_SHA::8}."
           fi
-
-          # Artifact dir -> "<repo>:<glob to upload>"
-          declare -A REPO=(
-            [kspaceFirstOrder-cuda-linux-13.0.0]="waltsims/kspaceFirstOrder-CUDA-linux:kspaceFirstOrder-CUDA"
-            [kspaceFirstOrder-cuda-windows-13.0.0]="waltsims/kspaceFirstOrder-CUDA-windows:*"
-            [kspaceFirstOrder-openmp-linux-ubuntu-latest]="waltsims/kspaceFirstOrder-OMP-linux:*"
-            [kspaceFirstOrder-openmp-windows-windows-latest]="waltsims/kspaceFirstOrder-OMP-windows:*"
-            [kspaceFirstOrder-openmp-darwin-macos-latest]="waltsims/k-wave-omp-darwin:*"
-          )
-
-          for dir in "${!REPO[@]}"; do
-            spec="${REPO[$dir]}"
-            repo="${spec%%:*}"
-            glob="${spec#*:}"
-
-            if [ ! -d "artifacts/$dir" ]; then
-              echo "::warning::Missing artifact dir artifacts/$dir; skipping $repo"
-              continue
-            fi
-
-            # Create the release on the target repo if it doesn't already exist
-            if ! gh release view "$VERSION" -R "$repo" >/dev/null 2>&1; then
-              gh release create "$VERSION" -R "$repo" \
-                --title "$VERSION" \
-                --notes "Auto-published from kspacefirstorder-unified@${GITHUB_SHA::8}."
-            fi
-
-            # Upload assets (overwrite if rerunning the workflow)
-            gh release upload "$VERSION" -R "$repo" --clobber \
-              artifacts/"$dir"/$glob
-          done
+          gh release upload "$VERSION" --clobber stage/*


### PR DESCRIPTION
## Summary

Flips the release flow from **five per-mirror releases** (the prior strategy, leftover from when binaries lived in separate repos) to **one unified release on this repo** containing all five platform binaries plus Windows runtime DLLs.

## Asset naming on the unified release

All five binaries land on a single tag with platform-suffixed names so nothing collides:

| Asset | Source artifact |
|---|---|
| \`kspaceFirstOrder-CUDA-linux\` | cuda-linux-13.0.0 |
| \`kspaceFirstOrder-OMP-linux\` | openmp-linux |
| \`kspaceFirstOrder-OMP-darwin\` | openmp-darwin |
| \`kspaceFirstOrder-CUDA-windows.exe\` | cuda-windows-13.0.0 |
| \`kspaceFirstOrder-OMP-windows.exe\` | openmp-windows |
| \`*.dll\` (vcpkg + MSVC runtime) | openmp-windows |

Windows DLLs ship once (from the OMP build) and serve both Windows backends — same pattern k-wave-python already uses in \`kwave/bin/windows/\`.

## What dropped

- \`BINARY_RELEASE_TOKEN\` PAT — no longer needed. The release lives on this repo, so default \`GITHUB_TOKEN\` with \`contents: write\` suffices.
- The 5-repo upload loop and the cross-repo asset-glob mapping.

## What stayed

- \`workflow_dispatch\` with \`version\` + \`dry_run\` inputs — manual trigger, default dry-run = on.
- Build via the existing \`ci-multi-platform.yml\` reusable workflow (no duplication of the build matrix).

## First release under this flow

**v1.4.2** — same binary contents as v1.4.1 (Linux static-linked, darwin fast-math fix), just published from this repo instead of five mirrors. The Windows pin in k-wave-python remains v1.3.0 until [unified#14](https://github.com/waltsims/kspacefirstorder-unified/issues/14) (OMP DLL packaging validation) and [unified#17](https://github.com/waltsims/kspacefirstorder-unified/issues/17) (CUDA DLL packaging) land — those follow-ups will go out as v1.4.3 or v1.5.0.

## Sister PR

[k-wave-python#738](https://github.com/waltsims/k-wave-python/issues/738) — flips \`URL_DICT\` in \`kwave/__init__.py\` to consume from this unified release. Lands in k-wave-python v0.6.3 / v0.7.0 after v1.4.2 ships and validates.

## Refs

- Closes step 4 of waltsims/kspacefirstorder-unified#13
- Partner: waltsims/k-wave-python#738

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites the release workflow from five separate per-mirror repository releases to a single unified release on this repo, simplifying the release process and eliminating the need for a cross-repo `BINARY_RELEASE_TOKEN` PAT.

- Permissions are correctly tightened: `contents: write` is scoped to the `publish` job only, while the `build` job (calling `ci-multi-platform.yml` with third-party actions and external clones) inherits the workflow-level `contents: read`.
- Pre-release version detection is added via regex and `-*` suffix check, correctly setting `--prerelease` on the `gh release create` call when a suffix like `-rc1` or `-beta` is present.
- Asset staging renames binaries with platform suffixes so all five files coexist on one release tag without collision, with Windows runtime DLLs sourced from the OMP build.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the workflow logic is correct, permissions are properly scoped, and the asset staging and upload steps are well-structured.

The rewrite correctly consolidates five cross-repo release steps into one, permissions are now job-scoped rather than workflow-wide, prerelease detection is handled correctly, and the dry-run / publish branching is clean. No defects were found in the changed code.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release-on-tag.yml | Rewrites release flow from five per-mirror releases to a single unified release; permissions correctly tightened to job scope, prerelease detection added, asset staging and upload logic look correct. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor Operator
    participant GH as GitHub Actions
    participant Build as build job<br/>(ci-multi-platform.yml)
    participant Publish as publish job<br/>(ubuntu-latest)
    participant Release as GitHub Release<br/>(this repo)

    Operator->>GH: workflow_dispatch(version, dry_run)
    GH->>Build: trigger (contents:read)
    Build-->>GH: upload 5 artifacts

    GH->>Publish: trigger after build (contents:write)
    Publish->>Publish: "Parse & validate version, detect prerelease suffix"
    Publish->>GH: "download-artifact@v4 → artifacts/"
    Publish->>Publish: stage/ ← cp with platform-suffixed names

    alt "dry_run = true"
        Publish->>Publish: print notice, list stage/, exit
    else "dry_run = false"
        Publish->>Release: gh release view VERSION
        alt release does not exist
            Publish->>Release: gh release create VERSION
        end
        Publish->>Release: "gh release upload --clobber stage/*"
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/release-on-tag.yml`, line 36 ([link](https://github.com/waltsims/kspacefirstorder-unified/blob/84bb4027de07a62ed7793c2a9afd2e44cd7bd4b7/.github/workflows/release-on-tag.yml#L36)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Unused CUDA 12.2.0 artifact wastes CI minutes**

   `ci-multi-platform.yml` builds the `linux-cuda` job for both `12.2.0` and `13.0.0` in a matrix. Only `kspaceFirstOrder-cuda-linux-13.0.0` is staged and released; the `12.2.0` artifact is downloaded and then silently discarded. Since `workflow_call: {}` accepts no inputs, the release workflow cannot prune the matrix today. This doubles the CUDA-Linux build time on every release run. Consider either adding a `cuda_version` input to `workflow_call` or documenting why the `12.2.0` matrix slot is kept.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["simplify: dedupe version parsing, tighte..."](https://github.com/waltsims/kspacefirstorder-unified/commit/6c3670364f1a47cbaf210a32f5891dfe7c4d8967) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32554618)</sub>

<!-- /greptile_comment -->