### PR TITLE
README: drop stale submodule step, add repo layout overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,29 @@ This project builds on the great work of the original k-Wave authors: B. E. Tree
 
 This project is a unified C++ implementation of the k-Wave toolbox that accelerates 2D/3D simulations using optimized implementations.
 
+## Repository layout
+
+All five platform/backend variants live in-tree under `repos/`:
+
+- `repos/kspaceFirstOrder-cuda-linux/` — Linux CUDA
+- `repos/kspaceFirstOrder-cuda-windows/` — Windows CUDA
+- `repos/kspaceFirstOrder-openmp-linux/` — Linux OpenMP
+- `repos/kspaceFirstOrder-openmp-windows/` — Windows OpenMP
+- `repos/kspaceFirstOrder-openmp-darwin/` — macOS OpenMP
+
+Each used to be a separate mirror repo, consolidated here as `git subtree`s (with history preserved). See [`plans/ROADMAP.md`](plans/ROADMAP.md) for what's next.
+
 ## Building
+
+All five variants build via [`.github/workflows/ci-multi-platform.yml`](.github/workflows/ci-multi-platform.yml) — that workflow is the canonical reference for the exact CMake invocations, dependency setup, and platform pinning per build.
 
 ### Windows (OpenMP via CMake + vcpkg)
 
-The Windows OpenMP implementation now ships with a CMake build that mirrors the upstream `kspaceFirstOrder-OMP-windows` repository and is exercised by the `windows-openmp` job in `.github/workflows/ci-multi-platform.yml`. To reproduce the build locally:
+Worked example. Reproduces the CI `windows-openmp` job locally:
 
 1. Install Visual Studio 2022 (Desktop development with C++ workload), [Ninja](https://ninja-build.org/), and bootstrap [vcpkg](https://github.com/microsoft/vcpkg) (for example into `C:\vcpkg`).
-2. Update submodules so the Windows sources and manifest (`vcpkg.json`) are present:
 
-   ```powershell
-   git submodule update --init --recursive
-   ```
-
-3. Configure the build, pointing CMake at the Windows OpenMP tree and the vcpkg toolchain:
+2. Configure the build, pointing CMake at the Windows OpenMP tree and the vcpkg toolchain:
 
    ```powershell
    cmake -S repos/kspaceFirstOrder-openmp-windows -B build/openmp-windows `
@@ -38,7 +47,7 @@ The Windows OpenMP implementation now ships with a CMake build that mirrors the 
 
    The manifest automatically pulls FFTW, HDF5 (with zlib + szip), and zlib through vcpkg—no manual `vcpkg install` commands are required.
 
-4. Build the executable:
+3. Build the executable:
 
    ```powershell
    cmake --build build/openmp-windows --config Release --parallel


### PR DESCRIPTION
## Summary

After #18, all five build trees became in-tree subtrees (not submodules), so `git submodule update --init --recursive` is a no-op that misleads readers. This PR:

- Drops the stale submodule step from the Windows-OpenMP recipe and renumbers
- Replaces "mirrors the upstream `kspaceFirstOrder-OMP-windows` repository" framing with a small **Repository layout** section listing all five in-tree variants
- Frames the documented Windows-OpenMP recipe as a worked example, with [`.github/workflows/ci-multi-platform.yml`](https://github.com/waltsims/kspacefirstorder-unified/blob/main/.github/workflows/ci-multi-platform.yml) as the canonical build reference (since all 5 variants now build here)

## Out of scope

- Documenting build recipes for the other 4 variants (Linux OMP/CUDA, Windows CUDA, macOS OMP) — they'd duplicate what's already in CI; the workflow file is the source of truth.
- A **Releases** / how-to-consume-binaries section — the release flow is still being rewritten in #19; documenting it now would be stale within a day.

## Refs

- Follows #18 (consolidation), #21 (stale workflow cleanup), #22 (plans cleanup)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleans up the README after #18 consolidated five separate mirror repos into in-tree `git subtree`s: it removes the now-obsolete `git submodule update --init --recursive` step and adds a **Repository layout** section that lists all five `repos/` variants. The Windows-OpenMP build recipe is reframed as a worked example, with the CI workflow file pointed to as the canonical build reference.

- Drops the stale submodule init command and renumbers the Windows build steps from 4 to 3.
- Adds a new **Repository layout** section enumerating the five in-tree subtrees and linking to `plans/ROADMAP.md` — that file does not currently exist, producing a broken link for readers.
- Adds a prose line in the **Building** section directing readers to `.github/workflows/ci-multi-platform.yml` as the authoritative build reference.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the broken link to plans/ROADMAP.md is resolved; all other changes are correct documentation cleanup.

The submodule removal and step renumbering are accurate and the CI workflow link is valid. The one issue is the reference to plans/ROADMAP.md, which does not exist in the repository — anyone who clicks it will get a 404.

README.md — the link to plans/ROADMAP.md needs to be corrected or removed.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Drops stale submodule step, adds Repository layout section and CI workflow reference; contains one broken link to plans/ROADMAP.md which does not exist. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Reader clones repo] --> B[README: Repository layout section]
    B --> C{repos/ subtrees}
    C --> D[kspaceFirstOrder-cuda-linux]
    C --> E[kspaceFirstOrder-cuda-windows]
    C --> F[kspaceFirstOrder-openmp-linux]
    C --> G[kspaceFirstOrder-openmp-windows]
    C --> H[kspaceFirstOrder-openmp-darwin]
    B --> I[Link: plans/ROADMAP.md]
    I --> J[❌ File does not exist — 404]
    B --> K[README: Building section]
    K --> L[CI workflow — canonical reference ✅]
    K --> M[Windows OpenMP worked example]
    M --> N[Step 1: Install VS2022 + Ninja + vcpkg]
    N --> O[Step 2: cmake configure]
    O --> P[Step 3: cmake build]
```

<sub>Reviews (1): Last reviewed commit: ["README: remove stale submodule step, add..."](https://github.com/waltsims/kspacefirstorder-unified/commit/e3db08111322b28fe494a6f13ea0b1b97fdaa69a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32562161)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->