### PR TITLE
Expand CUDA arch coverage to Blackwell variants + fix Windows arch list bug

### DIFF
--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -253,33 +253,20 @@ jobs:
           non-cuda-sub-packages: '[]'
           log-file-suffix: ${{ matrix.cuda-version }}.log.txt
 
-      - name: Register CUDA MSBuild customizations
+      - name: Install Ninja
         shell: pwsh
         run: |
-          $vsPath = & "${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.Component.MSBuild -property installationPath
-          if (-not $vsPath) {
-            throw "Failed to locate Visual Studio installation"
+          choco install ninja --no-progress -y
+          $ninja = (Get-Command ninja.exe -ErrorAction SilentlyContinue).Source
+          if (-not $ninja) {
+            $ninja = "C:\ProgramData\chocolatey\bin\ninja.exe"
           }
-          & "$vsPath\Common7\Tools\VsDevCmd.bat" -no_logo -arch=amd64 -host_arch=amd64 | Out-Null
-          if (-not $env:CUDA_PATH) {
-            throw "CUDA_PATH is not set after toolkit installation"
+          if (-not (Test-Path $ninja)) {
+            throw "Unable to locate ninja.exe after installation"
           }
-          if (-not $env:VCTargetsPath) {
-            $vcTargets = Join-Path $vsPath 'MSBuild/Microsoft/VC/v170'
-            if (-not (Test-Path $vcTargets)) {
-              throw "Unable to determine VCTargetsPath under $vsPath"
-            }
-            $env:VCTargetsPath = $vcTargets
-          }
-          $src = Join-Path $env:CUDA_PATH 'extras\visual_studio_integration\MSBuildExtensions'
-          $dest = Join-Path $env:VCTargetsPath 'BuildCustomizations'
-          Write-Host "Copying CUDA build customizations from $src to $dest"
-          if (-not (Test-Path $src)) {
-            throw "Expected MSBuildExtensions directory not found at $src"
-          }
-          New-Item -ItemType Directory -Path $dest -Force | Out-Null
-          Copy-Item -Path (Join-Path $src 'CUDA*.props') -Destination $dest -Force
-          Copy-Item -Path (Join-Path $src 'CUDA*.targets') -Destination $dest -Force
+          Split-Path $ninja | Out-File -FilePath $env:GITHUB_PATH -Append
+          "CMAKE_MAKE_PROGRAM=$ninja" | Out-File -FilePath $env:GITHUB_ENV -Append
+          & $ninja --version
 
       - name: Install vcpkg and dependencies (HDF5 + zlib)
         shell: pwsh
@@ -313,13 +300,12 @@ jobs:
       - name: Configure (CUDA, Windows)
         shell: pwsh
         env:
-          CMAKE_GENERATOR: "Visual Studio 17 2022"
-          CMAKE_GENERATOR_PLATFORM: x64
-          CMAKE_GENERATOR_TOOLSET: host=x64
           VCPKG_ROOT: ${{ env.VCPKG_ROOT }}
         run: |
           $env:PATH = "$env:VCPKG_ROOT;${env:PATH}"
           cmake -S repos/kspaceFirstOrder-cuda-windows -B build/cuda-windows `
+            -G "Ninja" `
+            -DCMAKE_MAKE_PROGRAM="$env:CMAKE_MAKE_PROGRAM" `
             -DCMAKE_BUILD_TYPE=Release `
             -DKSPACE_CPU_ARCH=avx2 `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
@@ -336,14 +322,14 @@ jobs:
       - name: Build (CUDA, Windows)
         shell: pwsh
         run: |
-          cmake --build build/cuda-windows --config Release -- /m
+          cmake --build build/cuda-windows
 
       - name: Embedded SASS architectures (Windows)
         shell: pwsh
         run: |
           Write-Host "::group::cuobjdump --list-elf"
           $cuobjdump = Get-Command cuobjdump -ErrorAction SilentlyContinue
-          $exe = "build/cuda-windows/Release/kspaceFirstOrder-CUDA.exe"
+          $exe = "build/cuda-windows/kspaceFirstOrder-CUDA.exe"
           if ($cuobjdump -and (Test-Path $exe)) {
             $sassLog = Join-Path $env:RUNNER_TEMP 'sass-list.txt'
             & $cuobjdump.Source --list-elf $exe | Tee-Object -FilePath $sassLog

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -134,10 +134,29 @@ jobs:
             -DHDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial \
             -DCUDAToolkit_ROOT=/usr/local/cuda
 
+      - name: Print shipped CUDA architectures (Linux)
+        run: |
+          echo "::group::Final CMAKE_CUDA_ARCHITECTURES (post-filter)"
+          cmake -L -N build/cuda-linux 2>/dev/null | grep -i cuda_architectures || true
+          echo "::endgroup::"
+
       - name: Build (CUDA, Linux)
         run: |
           set -euxo pipefail
           cmake --build build/cuda-linux --parallel "$(nproc)"
+
+      - name: Embedded SASS architectures (Linux)
+        run: |
+          echo "::group::cuobjdump --list-elf"
+          if command -v cuobjdump >/dev/null; then
+            cuobjdump --list-elf build/cuda-linux/kspaceFirstOrder-CUDA | tee /tmp/sass-list.txt
+            echo ""
+            echo "Unique compute capabilities embedded:"
+            grep -oE 'sm_[0-9]+a?' /tmp/sass-list.txt | sort -u
+          else
+            echo "::warning::cuobjdump not found; cannot inventory shipped archs"
+          fi
+          echo "::endgroup::"
 
       - name: Verify static linkage (CUDA, Linux)
         run: scripts/check-linux-binary-deps.sh build/cuda-linux/kspaceFirstOrder-CUDA cuda
@@ -304,10 +323,38 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET=x64-windows
 
+      - name: Print shipped CUDA architectures (Windows)
+        shell: pwsh
+        run: |
+          Write-Host "::group::Final CMAKE_CUDA_ARCHITECTURES (post-filter)"
+          $cacheDump = & cmake -L -N build/cuda-windows 2>$null
+          $cacheDump | Where-Object { $_ -match 'cuda_architectures' } | ForEach-Object { Write-Host $_ }
+          Write-Host "::endgroup::"
+
       - name: Build (CUDA, Windows)
         shell: pwsh
         run: |
           cmake --build build/cuda-windows --config Release -- /m
+
+      - name: Embedded SASS architectures (Windows)
+        shell: pwsh
+        run: |
+          Write-Host "::group::cuobjdump --list-elf"
+          $cuobjdump = Get-Command cuobjdump -ErrorAction SilentlyContinue
+          $exe = "build/cuda-windows/Release/kspaceFirstOrder-CUDA.exe"
+          if ($cuobjdump -and (Test-Path $exe)) {
+            $sassLog = Join-Path $env:RUNNER_TEMP 'sass-list.txt'
+            & $cuobjdump.Source --list-elf $exe | Tee-Object -FilePath $sassLog
+            Write-Host ""
+            Write-Host "Unique compute capabilities embedded:"
+            Select-String -Path $sassLog -Pattern 'sm_[0-9]+a?' -AllMatches |
+              ForEach-Object { $_.Matches } |
+              ForEach-Object { $_.Value } |
+              Sort-Object -Unique
+          } else {
+            Write-Warning "cuobjdump not found or exe missing; cannot inventory shipped archs"
+          }
+          Write-Host "::endgroup::"
 
       - name: Collect runtime DLLs (CUDA Windows)
         # Ship the CUDA exe with every non-system runtime it needs on a

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -354,7 +354,7 @@ jobs:
         # CUDA runtime DLLs from the installed toolkit.
         shell: pwsh
         run: |
-          $dest = "build/cuda-windows/Release"
+          $dest = "build/cuda-windows"
           if (-not (Test-Path "$dest/kspaceFirstOrder-CUDA.exe")) {
             throw "CUDA exe not found in expected artifact directory: $dest"
           }
@@ -435,7 +435,7 @@ jobs:
       - name: Verify CUDA Windows artifact
         shell: pwsh
         run: |
-          $dest = "build/cuda-windows/Release"
+          $dest = "build/cuda-windows"
           foreach ($pattern in @(
             "kspaceFirstOrder-CUDA.exe",
             "cudart64_*.dll",
@@ -474,8 +474,8 @@ jobs:
         with:
           name: kspaceFirstOrder-cuda-windows-${{ matrix.cuda-version }}
           path: |
-            build/cuda-windows/Release/kspaceFirstOrder-CUDA.exe
-            build/cuda-windows/Release/*.dll
+            build/cuda-windows/kspaceFirstOrder-CUDA.exe
+            build/cuda-windows/*.dll
           if-no-files-found: error
 
       - name: Build diagnostics (CUDA Windows)

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -236,8 +236,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2.0.0
+      - name: Setup MSVC dev env
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - name: Install CUDA Toolkit (Windows)
         uses: N-Storm/cuda-toolkit@v0.2.27m

--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -225,7 +225,11 @@ jobs:
           cmake --version
 
   windows-cuda:
-    runs-on: windows-latest
+    # Pin to windows-2022 (VS 2022). windows-latest now ships VS 2026 (v18),
+    # which CUDA 13.0's host_config.h rejects: "Only the versions between
+    # 2019 and 2022 (inclusive) are supported". CUDA hasn't shipped VS 2026
+    # support yet; bump back to windows-latest once it does.
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:

--- a/repos/kspaceFirstOrder-cuda-linux/CMakeLists.txt
+++ b/repos/kspaceFirstOrder-cuda-linux/CMakeLists.txt
@@ -27,11 +27,18 @@ set(KSPACE_CUDA_ARCH_LIST "" CACHE STRING "Override CUDA architectures (semicolo
 if(KSPACE_CUDA_ARCH_LIST)
   set(CMAKE_CUDA_ARCHITECTURES "${KSPACE_CUDA_ARCH_LIST}")
 elseif(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  # Default to modern architectures supported by current CUDA toolkits.
-  # sm_100/sm_120 (Blackwell) require CUDA 12.8+; SetupCUDA.cmake drops
-  # them automatically when an older toolchain is detected.
-  # Override via KSPACE_CUDA_ARCH_LIST if needed.
-  set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;120")
+  # Default to every architecture supported by current CUDA 13.x toolkits:
+  #   Turing (sm_75), Ampere (sm_80/86/87), Ada (sm_89),
+  #   Hopper (sm_90/90a),
+  #   Blackwell datacenter (sm_100/100a) + Ultra refresh (sm_103/103a),
+  #   Jetson Thor (sm_110),
+  #   Blackwell consumer (sm_120/120a),
+  #   GB10 / DGX Spark (sm_121/121a).
+  # SetupCUDA.cmake's pre-filter drops archs the installed toolkit doesn't accept
+  # (sm_100/100a/120/120a require nvcc >= 12.8; sm_103/103a/110/121/121a require nvcc >= 13.0).
+  # Maxwell / Pascal / Volta (sm_50-72) are not supported — removed from nvcc in CUDA 13.0.
+  # Override via -DKSPACE_CUDA_ARCH_LIST=... if needed.
+  set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;100a;103;103a;110;120;120a;121;121a")
 endif()
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/SetupCUDA.cmake)

--- a/repos/kspaceFirstOrder-cuda-linux/cmake/SetupCUDA.cmake
+++ b/repos/kspaceFirstOrder-cuda-linux/cmake/SetupCUDA.cmake
@@ -164,7 +164,8 @@ endfunction()
 #   https://github.com/rapidsai/rapids-cmake/blob/branch-23.09/rapids-cmake/cuda/set_architectures.cmake#L60)
 # We need to have our own logic to select our own architectures and create PTX for the latest arch
 # for forward compatibility. Only keep the default cmake behavior for native archs input.
-# Start with "70", this is the lowest architecture supported by cuFFTDx
+# Start with "75" (Turing). CUDA 13.0 removed nvcc support for Maxwell (sm_5x),
+# Pascal (sm_6x), and Volta (sm_70/72); the floor here is set by nvcc, not cuFFT.
 if(CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
     set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;100a;103;103a;110;120;120a;121;121a")
     update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)

--- a/repos/kspaceFirstOrder-cuda-linux/cmake/SetupCUDA.cmake
+++ b/repos/kspaceFirstOrder-cuda-linux/cmake/SetupCUDA.cmake
@@ -35,9 +35,10 @@ endif()
 # CMAKE_CUDA_COMPILER_VERSION is set and our post-enable filter (in
 # update_cmake_cuda_architectures below) gets a chance to run.
 #
-# Currently this only needs to handle the Blackwell archs (100, 120)
-# which require nvcc >= 12.8; older arches in our default list
-# (75..90a) work on every nvcc the project supports.
+# Currently this needs to handle the Blackwell archs (100/100a/120/120a)
+# which require nvcc >= 12.8, and Blackwell-refresh / Jetson Thor /
+# GB10 (103/103a/110/121/121a) which require nvcc >= 13.0; older arches
+# in our default list (75..90a) work on every nvcc the project supports.
 if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
     if(NOT DEFINED CMAKE_CUDA_COMPILER)
         find_program(_probe_nvcc nvcc
@@ -62,6 +63,25 @@ if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
                     endif()
                 endforeach()
             endif()
+            # Blackwell arch-specific variants share the 12.8 floor with their base archs
+            if(_probe_cuda_num LESS 1208)
+                foreach(_blackwell_arch IN ITEMS "100a" "120a")
+                    if("${_blackwell_arch}" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+                        message(STATUS "Pre-filter: dropping sm_${_blackwell_arch} (Blackwell) — nvcc ${CMAKE_MATCH_1}.${CMAKE_MATCH_2} predates 12.8")
+                        list(REMOVE_ITEM CMAKE_CUDA_ARCHITECTURES "${_blackwell_arch}")
+                    endif()
+                endforeach()
+            endif()
+
+            # Blackwell-refresh (B300), Jetson Thor, GB10/DGX Spark require nvcc >= 13.0
+            if(_probe_cuda_num LESS 1300)
+                foreach(_b300_arch IN ITEMS "103" "103a" "110" "121" "121a")
+                    if("${_b300_arch}" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+                        message(STATUS "Pre-filter: dropping sm_${_b300_arch} (Blackwell-refresh/Thor/GB10) — nvcc ${CMAKE_MATCH_1}.${CMAKE_MATCH_2} predates 13.0")
+                        list(REMOVE_ITEM CMAKE_CUDA_ARCHITECTURES "${_b300_arch}")
+                    endif()
+                endforeach()
+            endif()
         endif()
     endif()
 endif()
@@ -75,6 +95,22 @@ function(update_cmake_cuda_architectures supported_archs warn)
     list(APPEND CMAKE_MESSAGE_CONTEXT "update_cmake_cuda_architectures")
 
     if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0.0)
+            foreach(_b300_arch IN ITEMS "103" "103a" "110" "121" "121a")
+                if("${_b300_arch}" IN_LIST supported_archs AND ${warn})
+                    message(WARNING "sm${_b300_arch} (Blackwell-refresh/Thor/GB10) not supported with nvcc < 13.0.0")
+                endif()
+                list(REMOVE_ITEM supported_archs "${_b300_arch}")
+            endforeach()
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8.0)
+            foreach(_blackwell_arch IN ITEMS "100a" "120a")
+                if("${_blackwell_arch}" IN_LIST supported_archs AND ${warn})
+                    message(WARNING "sm${_blackwell_arch} (Blackwell) not supported with nvcc < 12.8.0")
+                endif()
+                list(REMOVE_ITEM supported_archs "${_blackwell_arch}")
+            endforeach()
+        endif()
         if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8.0)
             foreach(_blackwell_arch IN ITEMS "100" "120")
                 if("${_blackwell_arch}" IN_LIST supported_archs AND ${warn})
@@ -130,10 +166,10 @@ endfunction()
 # for forward compatibility. Only keep the default cmake behavior for native archs input.
 # Start with "70", this is the lowest architecture supported by cuFFTDx
 if(CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
-    set(CMAKE_CUDA_ARCHITECTURES "70;72;75;80;86;87;89;90;90a;100;120")
+    set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;100a;103;103a;110;120;120a;121;121a")
     update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)
 elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major")
-    set(CMAKE_CUDA_ARCHITECTURES "70;80;90;100")
+    set(CMAKE_CUDA_ARCHITECTURES "75;80;90;100;120")
     update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)
 elseif(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
     update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" TRUE)

--- a/repos/kspaceFirstOrder-cuda-windows/CMakeLists.txt
+++ b/repos/kspaceFirstOrder-cuda-windows/CMakeLists.txt
@@ -7,7 +7,15 @@ if(POLICY CMP0146)
   cmake_policy(SET CMP0146 NEW) # CUDA Clang host compilation
 endif()
 
-project(kspaceFirstOrderCUDA LANGUAGES CXX CUDA)
+## NOTE: do NOT add CUDA here. project(... LANGUAGES ... CUDA) calls
+## enable_language(CUDA) immediately, which captures CMAKE_CUDA_ARCHITECTURES
+## from nvcc's default (sm_75) BEFORE the elseif(NOT DEFINED ...) block below
+## gets a chance to set the multi-arch default — silently degrading the
+## Windows build to a single-arch SASS section (the v1.4.1 regression that
+## produced a 3.4 MB Windows exe vs Linux's 298 MB 9-arch fat binary).
+## SetupCUDA.cmake calls enable_language(CUDA) itself, AFTER our default
+## arch list is in place.
+project(kspaceFirstOrderCUDA LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -27,11 +35,18 @@ set(KSPACE_CUDA_ARCH_LIST "" CACHE STRING "Override CUDA architectures (semicolo
 if(KSPACE_CUDA_ARCH_LIST)
   set(CMAKE_CUDA_ARCHITECTURES "${KSPACE_CUDA_ARCH_LIST}")
 elseif(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  # Default to modern architectures supported by current CUDA toolkits.
-  # sm_100/sm_120 (Blackwell) require CUDA 12.8+; SetupCUDA.cmake drops
-  # them automatically when an older toolchain is detected.
-  # Override via KSPACE_CUDA_ARCH_LIST if needed.
-  set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;120")
+  # Default to every architecture supported by current CUDA 13.x toolkits:
+  #   Turing (sm_75), Ampere (sm_80/86/87), Ada (sm_89),
+  #   Hopper (sm_90/90a),
+  #   Blackwell datacenter (sm_100/100a) + Ultra refresh (sm_103/103a),
+  #   Jetson Thor (sm_110),
+  #   Blackwell consumer (sm_120/120a),
+  #   GB10 / DGX Spark (sm_121/121a).
+  # SetupCUDA.cmake's pre-filter drops archs the installed toolkit doesn't accept
+  # (sm_100/100a/120/120a require nvcc >= 12.8; sm_103/103a/110/121/121a require nvcc >= 13.0).
+  # Maxwell / Pascal / Volta (sm_50-72) are not supported — removed from nvcc in CUDA 13.0.
+  # Override via -DKSPACE_CUDA_ARCH_LIST=... if needed.
+  set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;100a;103;103a;110;120;120a;121;121a")
 endif()
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/SetupCUDA.cmake)

--- a/repos/kspaceFirstOrder-cuda-windows/cmake/SetupCUDA.cmake
+++ b/repos/kspaceFirstOrder-cuda-windows/cmake/SetupCUDA.cmake
@@ -164,7 +164,8 @@ endfunction()
 #   https://github.com/rapidsai/rapids-cmake/blob/branch-23.09/rapids-cmake/cuda/set_architectures.cmake#L60)
 # We need to have our own logic to select our own architectures and create PTX for the latest arch
 # for forward compatibility. Only keep the default cmake behavior for native archs input.
-# Start with "70", this is the lowest architecture supported by cuFFTDx
+# Start with "75" (Turing). CUDA 13.0 removed nvcc support for Maxwell (sm_5x),
+# Pascal (sm_6x), and Volta (sm_70/72); the floor here is set by nvcc, not cuFFT.
 if(CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
     set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;100a;103;103a;110;120;120a;121;121a")
     update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)

--- a/repos/kspaceFirstOrder-cuda-windows/cmake/SetupCUDA.cmake
+++ b/repos/kspaceFirstOrder-cuda-windows/cmake/SetupCUDA.cmake
@@ -35,9 +35,10 @@ endif()
 # CMAKE_CUDA_COMPILER_VERSION is set and our post-enable filter (in
 # update_cmake_cuda_architectures below) gets a chance to run.
 #
-# Currently this only needs to handle the Blackwell archs (100, 120)
-# which require nvcc >= 12.8; older arches in our default list
-# (75..90a) work on every nvcc the project supports.
+# Currently this needs to handle the Blackwell archs (100/100a/120/120a)
+# which require nvcc >= 12.8, and Blackwell-refresh / Jetson Thor /
+# GB10 (103/103a/110/121/121a) which require nvcc >= 13.0; older arches
+# in our default list (75..90a) work on every nvcc the project supports.
 if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
     if(NOT DEFINED CMAKE_CUDA_COMPILER)
         find_program(_probe_nvcc nvcc
@@ -62,6 +63,25 @@ if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
                     endif()
                 endforeach()
             endif()
+            # Blackwell arch-specific variants share the 12.8 floor with their base archs
+            if(_probe_cuda_num LESS 1208)
+                foreach(_blackwell_arch IN ITEMS "100a" "120a")
+                    if("${_blackwell_arch}" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+                        message(STATUS "Pre-filter: dropping sm_${_blackwell_arch} (Blackwell) — nvcc ${CMAKE_MATCH_1}.${CMAKE_MATCH_2} predates 12.8")
+                        list(REMOVE_ITEM CMAKE_CUDA_ARCHITECTURES "${_blackwell_arch}")
+                    endif()
+                endforeach()
+            endif()
+
+            # Blackwell-refresh (B300), Jetson Thor, GB10/DGX Spark require nvcc >= 13.0
+            if(_probe_cuda_num LESS 1300)
+                foreach(_b300_arch IN ITEMS "103" "103a" "110" "121" "121a")
+                    if("${_b300_arch}" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+                        message(STATUS "Pre-filter: dropping sm_${_b300_arch} (Blackwell-refresh/Thor/GB10) — nvcc ${CMAKE_MATCH_1}.${CMAKE_MATCH_2} predates 13.0")
+                        list(REMOVE_ITEM CMAKE_CUDA_ARCHITECTURES "${_b300_arch}")
+                    endif()
+                endforeach()
+            endif()
         endif()
     endif()
 endif()
@@ -75,6 +95,22 @@ function(update_cmake_cuda_architectures supported_archs warn)
     list(APPEND CMAKE_MESSAGE_CONTEXT "update_cmake_cuda_architectures")
 
     if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0.0)
+            foreach(_b300_arch IN ITEMS "103" "103a" "110" "121" "121a")
+                if("${_b300_arch}" IN_LIST supported_archs AND ${warn})
+                    message(WARNING "sm${_b300_arch} (Blackwell-refresh/Thor/GB10) not supported with nvcc < 13.0.0")
+                endif()
+                list(REMOVE_ITEM supported_archs "${_b300_arch}")
+            endforeach()
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8.0)
+            foreach(_blackwell_arch IN ITEMS "100a" "120a")
+                if("${_blackwell_arch}" IN_LIST supported_archs AND ${warn})
+                    message(WARNING "sm${_blackwell_arch} (Blackwell) not supported with nvcc < 12.8.0")
+                endif()
+                list(REMOVE_ITEM supported_archs "${_blackwell_arch}")
+            endforeach()
+        endif()
         if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8.0)
             foreach(_blackwell_arch IN ITEMS "100" "120")
                 if("${_blackwell_arch}" IN_LIST supported_archs AND ${warn})
@@ -130,10 +166,10 @@ endfunction()
 # for forward compatibility. Only keep the default cmake behavior for native archs input.
 # Start with "70", this is the lowest architecture supported by cuFFTDx
 if(CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
-    set(CMAKE_CUDA_ARCHITECTURES "70;72;75;80;86;87;89;90;90a;100;120")
+    set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;100a;103;103a;110;120;120a;121;121a")
     update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)
 elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major")
-    set(CMAKE_CUDA_ARCHITECTURES "70;80;90;100")
+    set(CMAKE_CUDA_ARCHITECTURES "75;80;90;100;120")
     update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)
 elseif(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
     update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" TRUE)


### PR DESCRIPTION
## Summary

- Expands the default `CMAKE_CUDA_ARCHITECTURES` from 9 archs to 16, covering every shipping Blackwell variant: datacenter (sm_100/100a), Ultra refresh / B300 (sm_103/103a), Jetson Thor (sm_110), consumer + RTX PRO 6000 Blackwell (sm_120/120a), and GB10 / DGX Spark (sm_121/121a) — in addition to the existing Turing → Hopper coverage.
- Fixes a silent v1.4.1 Windows regression where the multi-arch default was being discarded and the Windows exe shipped with a single sm_75 SASS section (3.4 MB vs Linux's 298 MB).
- Extends `cmake/SetupCUDA.cmake` (both Linux + Windows copies) with pre-filter and post-enable-filter rules for the new archs, gated on the correct toolkit floors (12.8+ for the 'a' Blackwell variants, 13.0+ for B300/Thor/GB10 archs).
- Adds CI diagnostic steps so every release log records exactly which architectures were configured and which SASS sections were embedded in the shipped binary.

## Why the Windows fix

Build log from the v1.4.1 release run (workflow run id `26003758264`, headSha `9cd41a45`):

- **Linux (nvcc 13.0.0):** `-- Using CUDA architectures: 75-real;80-real;86-real;87-real;89-real;90-real;90a-real;100-real;120`
- **Windows (nvcc 13.0.0):** `-- Using CUDA architectures: 75` — every nvcc invocation reduces to `--generate-code=arch=compute_75,code=[compute_75,sm_75]`.

Resulting binary sizes: Linux 298 MB / Windows 3.4 MB (Windows ~1% of Linux because single-arch vs 9-arch fat binary).

Root cause: the Windows `CMakeLists.txt` was using `project(kspaceFirstOrderCUDA LANGUAGES CXX CUDA)`. That call invokes `enable_language(CUDA)` immediately, which captures `CMAKE_CUDA_ARCHITECTURES` from nvcc's bare default (sm_75) BEFORE the `elseif(NOT DEFINED CMAKE_CUDA_ARCHITECTURES) ... set(... "75;80;86;87;...")` block below ran. The Linux file uses `project(... LANGUAGES CXX)` (no CUDA) and so the default-list elseif fires correctly.

Fix: drop `CUDA` from the Windows `project()` call. `cmake/SetupCUDA.cmake` already calls `enable_language(CUDA)` itself, AFTER the default-list block, so the multi-arch list is now picked up the same way it is on Linux.

## What ships (before vs after)

| | v1.4.1 Linux | v1.4.1 Windows | v1.4.2 (this PR) |
| --- | --- | --- | --- |
| Configured archs | 9 (75-120, no 100a/103/110/121) | 1 (sm_75 only) | 16 (75-121a, all Blackwell variants) |
| Binary size (CUDA 13.0) | 298 MB | 3.4 MB | ~370-440 MB (est.) |
| Coverage | Turing → Hopper + partial Blackwell | Turing only | Turing → every shipping Blackwell |

The pre/post-filter ensures CUDA 12.x toolchains in the CI matrix (`12.2.0`) still build cleanly — they just drop the archs they cannot accept.

## Verification

- **Local probe with nvcc 13.3.33:** ran `cmake -S repos/kspaceFirstOrder-cuda-linux -B /tmp/build-probe -DCMAKE_BUILD_TYPE=Release -DCUDAToolkit_ROOT=...` and got: `-- Using CUDA architectures: 75-real;80-real;86-real;87-real;89-real;90-real;90a-real;100-real;100a-real;103-real;103a-real;110-real;120-real;120a-real;121-real;121a` — all 16 archs survive the pre-filter on a current toolkit, with PTX emitted only for the latest (121a).
- **Toolkit-floor matrix:** the local nvcc 13.3.33 test compile of a trivial `__global__` kernel succeeded for every arch in the new list; NVIDIA's nvcc 13.0 release notes list sm_75/80/86/87/89/90/90a/100/100a/103/103a/110/120/120a/121/121a as supported and explicitly remove Maxwell/Pascal/Volta (sm_50-72).
- **Kernel audit:** the 11 `.cu`/`.cuh` files use no arch-specific instructions (no wgmma, TMA, cluster cooperative groups, mma/wmma, async memcpy, half/bfloat16, `__ldg`, textures, atomics, shfl, or inline asm) — only `__syncwarp`, `__shared__`, and one informational `__CUDA_ARCH__` query. The 'a' variants are defensive headroom for future tensor-core / TMA / cluster work; we add no per-arch codegen yet.
- **Symmetry:** every new pre-filter rule has a matching post-enable rule (12.8 floor for 100a/120a; 13.0 floor for 103/103a/110/121/121a) so non-13.0 toolchains in the CI matrix degrade gracefully.

## Risks

- Build time grows roughly linearly with arch count (~16/9 = +75 %). Single-PR cost.
- Binary size grows by ~70-140 MB on Linux (from 298 MB), Windows jumps from 3.4 MB to whatever the full fat binary lands at (the previously-missing 8+ archs of SASS land in the binary). This is the explicit intent.
- The `'all'` and `'all-major'` magic strings in `SetupCUDA.cmake` change shape: `'all'` drops sm_70/72 (gone from CUDA 13.0) and gains every Blackwell variant; `'all-major'` drops sm_70 and adds sm_120. Direct override via `KSPACE_CUDA_ARCH_LIST=...` is unchanged.

## Notes

- Targeted for the v1.4.2 release.
- Partially addresses #17 (Windows CUDA packaging — the SASS-coverage half).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent Windows multi-arch regression (v1.4.1 shipped sm_75-only due to `project(... LANGUAGES CXX CUDA)` capturing nvcc's bare default before the arch-list block ran) and expands the default `CMAKE_CUDA_ARCHITECTURES` from 9 to 16 entries covering every shipping Blackwell variant. The CI stack is also modernised: MSBuild is replaced by Ninja, the runner is pinned to `windows-2022` (CUDA 13.0 rejects VS 2026), and diagnostic steps log the configured and embedded architectures for each release.

- **Windows fix**: Dropping `CUDA` from `project()` in `CMakeLists.txt` lets `SetupCUDA.cmake` call `enable_language(CUDA)` _after_ the default arch list is set, matching the Linux behaviour and restoring the full fat binary.
- **Arch expansion**: Both Linux and Windows now default to `75;80;86;87;89;90;90a;100;100a;103;103a;110;120;120a;121;121a`, with two-stage version-gated filters (pre-`enable_language` probe + post-`enable_language` `update_cmake_cuda_architectures`) so CUDA 12.2–12.7 CI builds degrade gracefully.
- **CI hardening**: Ninja replaces MSBuild, artifact paths lose the `Release/` subdirectory, and `cuobjdump --list-elf` output is captured for both Linux and Windows to verify SASS coverage in every release log.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The Windows project() fix is mechanically correct and explained by a clear root-cause analysis; the two-stage arch filter covers every nvcc version in the CI matrix without any gaps.

The core fix — removing CUDA from the Windows project() call — is a one-line change with an obvious, verified root cause. The arch-expansion logic adds symmetrical pre- and post-filter blocks for each version floor; the sets are disjoint and the ordering is correct. All 6 CI jobs passed green with cuobjdump output confirming all 16 SASS sections in both Linux and Windows binaries. No logic errors or missing guards were found in the changed code paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci-multi-platform.yml | Pins Windows runner to windows-2022 (CUDA 13.0 host-compiler compatibility), switches MSBuild → Ninja, removes Release/ subdirectory from all artifact paths, and adds arch-diagnostic steps (cmake -L -N + cuobjdump) for both platforms. |
| repos/kspaceFirstOrder-cuda-linux/CMakeLists.txt | Updates default arch list from 9 to 16 entries, adding all Blackwell variants; comment accurately describes each arch group and its nvcc floor. |
| repos/kspaceFirstOrder-cuda-linux/cmake/SetupCUDA.cmake | Adds pre-filter and post-filter rules for 100a/120a (nvcc ≥ 12.8) and 103/103a/110/121/121a (nvcc ≥ 13.0); expands 'all' and 'all-major' magic-string lists; two consecutive VERSION_LESS 12.8.0 blocks in the post-filter are redundant but correct. |
| repos/kspaceFirstOrder-cuda-windows/CMakeLists.txt | Drops CUDA from project() to fix the v1.4.1 Windows single-arch regression; expands default arch list to all 16 Blackwell variants; well-commented with root-cause explanation. |
| repos/kspaceFirstOrder-cuda-windows/cmake/SetupCUDA.cmake | Identical changes to the Linux copy — pre-filter and post-filter rules are in sync; same two consecutive 12.8.0 blocks present. |

</details>


</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CMakeLists.txt sets CMAKE_CUDA_ARCHITECTURES\n(16 archs: 75…121a)\n\nWindows: project(LANGUAGES CXX) ← fix\nLinux:  project(LANGUAGES CXX)"] --> B

    B{"CMAKE_CUDA_ARCHITECTURES\n== 'native'?"}
    B -- Yes --> E
    B -- No --> C

    C["Pre-filter: probe nvcc --version\n(before enable_language)"] --> D

    D{"nvcc version?"}
    D -- "< 12.8" --> D1["Drop: 100 100a 120 120a"]
    D -- "< 13.0" --> D2["Drop: 103 103a 110 121 121a"]
    D -- ">= 13.0" --> E
    D1 --> E
    D2 --> E

    E["enable_language(CUDA)\n→ sets CMAKE_CUDA_COMPILER_VERSION"]

    E --> F{"Value of\nCMAKE_CUDA_ARCHITECTURES?"}
    F -- "'all'" --> G1["Expand to full 16-arch list"]
    F -- "'all-major'" --> G2["Expand: 75;80;90;100;120"]
    F -- "explicit list" --> H

    G1 --> H
    G2 --> H

    H["update_cmake_cuda_architectures()\nPost-filter by CMAKE_CUDA_COMPILER_VERSION\n< 13.0 → drop 103/103a/110/121/121a\n< 12.8 → drop 100a/120a\n< 12.8 → drop 100/120\n< 12.0 → drop 90a\n< 11.8 → drop 90/89 …"]

    H --> I["list(POP_BACK) last arch → PTX only\nAll others → SASS (-real)\nSet CMAKE_CUDA_ARCHITECTURES in parent scope"]

    I --> J["message STATUS 'Using CUDA architectures: ...'"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["CMakeLists.txt sets CMAKE_CUDA_ARCHITECTURES\n(16 archs: 75…121a)\n\nWindows: project(LANGUAGES CXX) ← fix\nLinux:  project(LANGUAGES CXX)"] --> B

    B{"CMAKE_CUDA_ARCHITECTURES\n== 'native'?"}
    B -- Yes --> E
    B -- No --> C

    C["Pre-filter: probe nvcc --version\n(before enable_language)"] --> D

    D{"nvcc version?"}
    D -- "< 12.8" --> D1["Drop: 100 100a 120 120a"]
    D -- "< 13.0" --> D2["Drop: 103 103a 110 121 121a"]
    D -- ">= 13.0" --> E
    D1 --> E
    D2 --> E

    E["enable_language(CUDA)\n→ sets CMAKE_CUDA_COMPILER_VERSION"]

    E --> F{"Value of\nCMAKE_CUDA_ARCHITECTURES?"}
    F -- "'all'" --> G1["Expand to full 16-arch list"]
    F -- "'all-major'" --> G2["Expand: 75;80;90;100;120"]
    F -- "explicit list" --> H

    G1 --> H
    G2 --> H

    H["update_cmake_cuda_architectures()\nPost-filter by CMAKE_CUDA_COMPILER_VERSION\n< 13.0 → drop 103/103a/110/121/121a\n< 12.8 → drop 100a/120a\n< 12.8 → drop 100/120\n< 12.0 → drop 90a\n< 11.8 → drop 90/89 …"]

    H --> I["list(POP_BACK) last arch → PTX only\nAll others → SASS (-real)\nSet CMAKE_CUDA_ARCHITECTURES in parent scope"]

    I --> J["message STATUS 'Using CUDA architectures: ...'"]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `repos/kspaceFirstOrder-cuda-linux/cmake/SetupCUDA.cmake`, line 106-121 ([link](https://github.com/waltsims/kspacefirstorder-unified/blob/315851a420b86f63ff86ef0ebdb104eafb3065b3/repos/kspaceFirstOrder-cuda-linux/cmake/SetupCUDA.cmake#L106-L121)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Two consecutive `if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8.0)` blocks in `update_cmake_cuda_architectures` check the same condition separately for `100a`/`120a` and `100`/`120`. They can be collapsed into a single block, matching the style of every other version-floor check in this function.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["ci: drop Release/ subdir from windows-cu..."](https://github.com/waltsims/kspacefirstorder-unified/commit/1422cb6bc6d0d7496b03128641aebf2deed8c4d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38865514)</sub>

<!-- /greptile_comment -->