### PR TITLE
release-on-tag: set GH_REPO so publish job doesn't need a git checkout

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -147,6 +147,11 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # No actions/checkout in this job, so gh CLI can't auto-detect the
+          # target repo from a git remote. Set GH_REPO explicitly to skip
+          # the git probe (otherwise: "failed to run git: fatal: not a git
+          # repository"). github.repository expands to e.g. "owner/repo".
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ steps.ver.outputs.version }}
           PRERELEASE: ${{ steps.ver.outputs.prerelease }}
         run: |


### PR DESCRIPTION
## Summary

The v1.4.2 release-on-tag run successfully built all 6 platform binaries and staged them, then failed in the **Publish release** step:

\`\`\`
+ gh release create v1.4.2 --title v1.4.2 --notes 'Unified binaries...'
failed to run git: fatal: not a git repository (or any of the parent directories): .git
\`\`\`

The publish job runs in a checkout-less environment (only artifact downloads + asset staging — no source clone needed). \`gh release create\` defaults to probing git for the target repo when \`--repo\` isn't passed; with no git context, it errors out.

## Fix

Set \`GH_REPO=\${{ github.repository }}\` in the Publish step's env block. gh CLI honors this env var and skips the git probe. Applies to both \`gh release create\` and \`gh release upload\` invocations without per-command changes.

## Why not actions/checkout

Cheaper. The publish job has no source-tree dependency — adding a checkout step burns ~5-10s per release for no functional gain. The env-var approach is also self-documenting (the env block makes the dependency explicit).

## After this merges

Re-dispatch \`release-on-tag.yml\` with \`version: v1.4.2\`, \`dry_run: false\`. With the DLL conflict warning (#28) and this GH_REPO fix both in place, publish should complete and v1.4.2 should appear on the Releases page with all platform binaries + DLL bundle attached.

## Test plan

- [ ] Workflow re-dispatch succeeds end-to-end (build + publish both green)
- [ ] v1.4.2 release exists with all expected assets

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken `Publish release` step by setting `GH_REPO=${{ github.repository }}` in the step's env block. Without a git checkout in the publish job, `gh` CLI was unable to auto-detect the target repo and exited with `fatal: not a git repository`.

- Adds `GH_REPO` to the existing env block on the "Publish release" step only; all three `gh` invocations in that step (`gh release view`, `gh release create`, `gh release upload`) automatically pick it up.
- Scoped entirely to the non-dry-run publish step — no other steps are affected and no checkout overhead is added.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line env addition is the idiomatic fix for checkout-less gh CLI usage and carries no functional risk.

The change adds a single, well-understood env var (GH_REPO) to one step. github.repository is a built-in Actions context value that is always populated and always in the correct owner/repo format gh expects. All three gh commands in the Publish step benefit automatically. There is nothing else changed, no logic is reordered, and no new permissions are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-on-tag.yml | Adds GH_REPO env var to the Publish release step so gh CLI can resolve the target repo without a git checkout; change is minimal, correctly scoped, and uses the standard gh CLI mechanism. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GHA as GitHub Actions
    participant Build as build job
    participant Publish as publish job
    participant GH as gh CLI
    participant API as GitHub Releases API

    GHA->>Build: Trigger (workflow_dispatch)
    Build-->>Publish: Artifacts (6 platform binaries + DLLs)

    Publish->>Publish: "Parse & validate version input"
    Publish->>Publish: Download artifacts
    Publish->>Publish: Stage platform-suffixed assets

    alt "dry_run = true"
        Publish->>GHA: Print dry-run summary (no gh call)
    else "dry_run = false"
        Note over Publish,GH: GH_REPO=github.repository set in env
        Publish->>GH: gh release view VERSION
        GH->>API: "GET /repos/{owner}/{repo}/releases/tags/{tag}"
        API-->>GH: 404 or 200
        opt release does not exist
            Publish->>GH: gh release create VERSION
            GH->>API: "POST /repos/{owner}/{repo}/releases"
            API-->>GH: 201 Created
        end
        Publish->>GH: "gh release upload VERSION --clobber stage/*"
        GH->>API: POST assets
        API-->>GH: 201 Created
        GH-->>Publish: Done
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GHA as GitHub Actions
    participant Build as build job
    participant Publish as publish job
    participant GH as gh CLI
    participant API as GitHub Releases API

    GHA->>Build: Trigger (workflow_dispatch)
    Build-->>Publish: Artifacts (6 platform binaries + DLLs)

    Publish->>Publish: "Parse & validate version input"
    Publish->>Publish: Download artifacts
    Publish->>Publish: Stage platform-suffixed assets

    alt "dry_run = true"
        Publish->>GHA: Print dry-run summary (no gh call)
    else "dry_run = false"
        Note over Publish,GH: GH_REPO=github.repository set in env
        Publish->>GH: gh release view VERSION
        GH->>API: "GET /repos/{owner}/{repo}/releases/tags/{tag}"
        API-->>GH: 404 or 200
        opt release does not exist
            Publish->>GH: gh release create VERSION
            GH->>API: "POST /repos/{owner}/{repo}/releases"
            API-->>GH: 201 Created
        end
        Publish->>GH: "gh release upload VERSION --clobber stage/*"
        GH->>API: POST assets
        API-->>GH: 201 Created
        GH-->>Publish: Done
    end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["release-on-tag: set GH\_REPO so publish j..."](https://github.com/waltsims/kspacefirstorder-unified/commit/c9a77b6f4922703c42a7d99e5ca0f116b14d4dd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38872277)</sub>

<!-- /greptile_comment -->