### PR TITLE
ci: pin windows-openmp to windows-2022 to match windows-cuda (closes #27)

### DIFF
--- a/.github/workflows/ci-multi-platform.yml
+++ b/.github/workflows/ci-multi-platform.yml
@@ -487,7 +487,13 @@ jobs:
           Get-ChildItem -Recurse -Filter *.targets "C:\Program Files (x86)\Microsoft Visual Studio" -ErrorAction SilentlyContinue | Select-Object -First 5 | ForEach-Object { $_.FullName }
 
   windows-openmp:
-    runs-on: windows-latest
+    # Pin to windows-2022 to match windows-cuda (which is forced to 2022 by
+    # CUDA 13.0's host_config.h check). Same MSVC version on both Windows
+    # jobs gives vcpkg the same compile environment for shared deps
+    # (HDF5/szip/zlib/MSVC CRT), which lets the release-on-tag staging step
+    # ship a single byte-identical DLL bundle instead of warning about
+    # backend-specific byte drift. Tracked in #27.
+    runs-on: windows-2022
     env:
       VCPKG_ROOT: C:\vcpkg
     steps:


### PR DESCRIPTION
## Summary

Pin \`windows-openmp\` to \`runs-on: windows-2022\` so both Windows jobs build on the same MSVC version. \`windows-cuda\` is already pinned there (forced by CUDA 13.0's host_config.h rejecting newer VS versions).

## Why

The v1.4.2 release showed \`::warning::DLL bytes differ: aec.dll\` (and friends) at the stage-assets step — backend-specific byte drift in vcpkg-built shared deps because each Windows job ran on a different MSVC version (\`windows-cuda\` on VS 2022 / MSVC 14.44, \`windows-openmp\` on VS 2026 / MSVC 14.51 from \`windows-latest\`). The conflict-warn fix (#28) lets the release publish anyway by picking CUDA's copy as canonical and dropping OMP's. That works but it's untidy.

This PR aligns the toolchains so the DLLs come out byte-identical and the warnings go away.

## Risk

Low. \`windows-2022\` is supported by GitHub Actions and matches what \`windows-cuda\` has been using successfully since #25. \`windows-openmp\`'s build is straightforward C++ + OpenMP + Ninja — no CUDA-specific toolchain concerns.

## Follow-up if not enough

If the post-merge release-on-tag run still shows \`::warning::DLL bytes differ\`, the next step is to unify vcpkg fetch flow: \`windows-openmp\` currently uses \`lukka/run-vcpkg@v11\` with GitHub Actions binary caching while \`windows-cuda\` manually clones + bootstraps. Different fetch paths can produce slightly different binaries even with identical compile toolchains. Pick one (probably lukka, it's the more modern flow) for both jobs. Tracked as an open question in #27.

## Test plan

- [ ] CI green on this PR (same matrix as before, just different windows-openmp runner)
- [ ] After merge: next release-on-tag run shows no \`::warning::DLL bytes differ\` messages in the stage-assets step

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes the `windows-openmp` CI job's runner label from `windows-latest` to `windows-2022` so both Windows jobs build under the same MSVC toolchain version as `windows-cuda`. This removes the vcpkg-built shared-DLL byte drift that was triggering warnings in the release staging step.

- **Runner pin**: `windows-latest` → `windows-2022` on the `windows-openmp` job (line 496); `windows-cuda` is already on `windows-2022` (line 232).
- **Comment added**: Explains the rationale (CUDA 13.0 `host_config.h` constraint, DLL byte-drift fix, and link to #27) directly above the `runs-on` field.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line runner label update with no functional logic involved.

Both Windows jobs now target the same well-established windows-2022 runner that windows-cuda has been using successfully since #25. The only risk would be if windows-2022 itself were removed from GitHub-hosted runners, which is a platform-level concern outside this PR's scope. The comment accurately documents the rationale and the open follow-up path in #27.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci-multi-platform.yml | Pins windows-openmp runner from windows-latest to windows-2022 to match windows-cuda, eliminating MSVC version skew that caused DLL byte drift in the release staging step. Well-commented one-liner change. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Release-on-tag trigger] --> B[windows-cuda\nruns-on: windows-2022\nMSVC 14.44]
    A --> C[windows-openmp\nruns-on: windows-2022 pinned\nMSVC 14.44]
    B --> D[vcpkg builds\nHDF5 / szip / zlib]
    C --> E[vcpkg builds\nHDF5 / szip / zlib]
    D --> F{stage-assets}
    E --> F
    F --> G[Byte-identical DLLs\nNo warning emitted]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Release-on-tag trigger] --> B[windows-cuda\nruns-on: windows-2022\nMSVC 14.44]
    A --> C[windows-openmp\nruns-on: windows-2022 pinned\nMSVC 14.44]
    B --> D[vcpkg builds\nHDF5 / szip / zlib]
    C --> E[vcpkg builds\nHDF5 / szip / zlib]
    D --> F{stage-assets}
    E --> F
    F --> G[Byte-identical DLLs\nNo warning emitted]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: pin windows-openmp to windows-2022 t..."](https://github.com/waltsims/kspacefirstorder-unified/commit/e31fd2c14da8c920bd3c8e356f0b6625abe85f8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38901989)</sub>

<!-- /greptile_comment -->